### PR TITLE
Updated AccessTokenResponseGenerator to work with key chain instead of registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+2.0.0
+-----
+
+* Updated `AccessTokenResponseGenerator` to generate for a key chain instead of a registration
+
 1.2.0
 -----
 

--- a/src/Service/Server/Factory/AuthorizationServerFactory.php
+++ b/src/Service/Server/Factory/AuthorizationServerFactory.php
@@ -28,7 +28,7 @@ use League\OAuth2\Server\CryptKey;
 use League\OAuth2\Server\Repositories\AccessTokenRepositoryInterface;
 use League\OAuth2\Server\Repositories\ClientRepositoryInterface;
 use League\OAuth2\Server\Repositories\ScopeRepositoryInterface;
-use OAT\Library\Lti1p3Core\Registration\RegistrationInterface;
+use OAT\Library\Lti1p3Core\Security\Key\KeyChainInterface;
 use OAT\Library\Lti1p3Core\Service\Server\Grant\ClientAssertionCredentialsGrant;
 use OAT\Library\Lti1p3Core\Service\Server\ResponseType\ScopedBearerTokenResponse;
 
@@ -58,15 +58,15 @@ class AuthorizationServerFactory
         $this->encryptionKey = $encryptionKey;
     }
 
-    public function createForRegistration(RegistrationInterface $registration): AuthorizationServer
+    public function create(KeyChainInterface $keyChain): AuthorizationServer
     {
-        if (null === $registration->getPlatformKeyChain()) {
-            throw new InvalidArgumentException('Missing platform key chain');
+        if (null === $keyChain->getPrivateKey()) {
+            throw new InvalidArgumentException('Missing private key');
         }
 
         $privateKey = new CryptKey(
-            $registration->getPlatformKeyChain()->getPrivateKey()->getContent(),
-            $registration->getPlatformKeyChain()->getPrivateKey()->getPassphrase(),
+            $keyChain->getPrivateKey()->getContent(),
+            $keyChain->getPrivateKey()->getPassphrase(),
             false
         );
 

--- a/src/Service/Server/Generator/AccessTokenResponseGenerator.php
+++ b/src/Service/Server/Generator/AccessTokenResponseGenerator.php
@@ -23,20 +23,20 @@ declare(strict_types=1);
 namespace OAT\Library\Lti1p3Core\Service\Server\Generator;
 
 use League\OAuth2\Server\Exception\OAuthServerException;
-use OAT\Library\Lti1p3Core\Registration\RegistrationRepositoryInterface;
+use OAT\Library\Lti1p3Core\Security\Key\KeyChainRepositoryInterface;
 use OAT\Library\Lti1p3Core\Service\Server\Factory\AuthorizationServerFactory;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
 class AccessTokenResponseGenerator
 {
-    /** @var RegistrationRepositoryInterface */
+    /** @var KeyChainRepositoryInterface */
     private $repository;
 
     /** @var AuthorizationServerFactory */
     private $factory;
 
-    public function __construct(RegistrationRepositoryInterface $repository, AuthorizationServerFactory $factory)
+    public function __construct(KeyChainRepositoryInterface $repository, AuthorizationServerFactory $factory)
     {
         $this->repository = $repository;
         $this->factory = $factory;
@@ -48,16 +48,16 @@ class AccessTokenResponseGenerator
     public function generate(
         ServerRequestInterface $request,
         ResponseInterface $response,
-        string $registrationIdentifier
+        string $keyChainIdentifier
     ): ResponseInterface {
-        $registration = $this->repository->find($registrationIdentifier);
+        $keyChain = $this->repository->find($keyChainIdentifier);
 
-        if (null === $registration) {
-            throw new OAuthServerException('Invalid registration identifier', 11, 'registration_not_found', 404);
+        if (null === $keyChain) {
+            throw new OAuthServerException('Invalid key chain identifier', 11, 'key_chain_not_found', 404);
         }
 
         return $this->factory
-            ->createForRegistration($registration)
+            ->create($keyChain)
             ->respondToAccessTokenRequest($request, $response);
     }
 }

--- a/tests/Integration/Service/Server/Generator/AccessTokenResponseGeneratorTest.php
+++ b/tests/Integration/Service/Server/Generator/AccessTokenResponseGeneratorTest.php
@@ -166,7 +166,7 @@ class AccessTokenResponseGeneratorTest extends TestCase
         $result = $this->subject->generate($request, $this->createResponse(), $keyChain->getIdentifier());
 
         $this->assertInstanceOf(ResponseInterface::class, $result);
-        $this->assertEquals(401 , $result->getStatusCode());
+        $this->assertEquals(401, $result->getStatusCode());
     }
 
     public function testGenerateWitInvalidKeyChain(): void
@@ -184,7 +184,7 @@ class AccessTokenResponseGeneratorTest extends TestCase
         );
 
         $this->assertInstanceOf(ResponseInterface::class, $result);
-        $this->assertEquals(401 , $result->getStatusCode());
+        $this->assertEquals(401, $result->getStatusCode());
     }
 
     private function generateCredentials(RegistrationInterface $registration, array $scopes = []): array

--- a/tests/Integration/Service/Server/Generator/AccessTokenResponseGeneratorTest.php
+++ b/tests/Integration/Service/Server/Generator/AccessTokenResponseGeneratorTest.php
@@ -30,6 +30,7 @@ use Lcobucci\JWT\Signer\Rsa\Sha256;
 use League\OAuth2\Server\Exception\OAuthServerException;
 use OAT\Library\Lti1p3Core\Message\MessageInterface;
 use OAT\Library\Lti1p3Core\Registration\RegistrationInterface;
+use OAT\Library\Lti1p3Core\Security\Key\KeyChainRepositoryInterface;
 use OAT\Library\Lti1p3Core\Service\Server\Generator\AccessTokenResponseGenerator;
 use OAT\Library\Lti1p3Core\Service\Server\Entity\Scope;
 use OAT\Library\Lti1p3Core\Service\Server\Factory\AuthorizationServerFactory;
@@ -39,6 +40,7 @@ use OAT\Library\Lti1p3Core\Service\Server\Repository\ClientRepository;
 use OAT\Library\Lti1p3Core\Service\Server\Repository\ScopeRepository;
 use OAT\Library\Lti1p3Core\Tests\Traits\DomainTestingTrait;
 use OAT\Library\Lti1p3Core\Tests\Traits\NetworkTestingTrait;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
 
@@ -50,6 +52,9 @@ class AccessTokenResponseGeneratorTest extends TestCase
     /** @var ArrayCachePool */
     private $cache;
 
+    /** @var KeyChainRepositoryInterface|MockObject */
+    private $keyChainRepositoryMock;
+
     /** @var AccessTokenResponseGenerator */
     private $subject;
 
@@ -57,27 +62,34 @@ class AccessTokenResponseGeneratorTest extends TestCase
     {
         $this->cache = new ArrayCachePool();
 
-        $registrationRepository = $this->createTestRegistrationRepository();
+        $this->keyChainRepositoryMock = $this->createMock(KeyChainRepositoryInterface::class);
 
         $factory = new AuthorizationServerFactory(
-            new ClientRepository($registrationRepository),
+            new ClientRepository($this->createTestRegistrationRepository()),
             new AccessTokenRepository($this->cache),
             new ScopeRepository([new Scope('scope1'), new Scope('scope2')]),
             'encryptionKey'
         );
 
-        $this->subject = new AccessTokenResponseGenerator($registrationRepository, $factory);
+        $this->subject = new AccessTokenResponseGenerator($this->keyChainRepositoryMock, $factory);
     }
 
     public function testGenerate(): void
     {
+        $keyChain = $this->createTestKeyChain();
+        $this->keyChainRepositoryMock
+            ->expects($this->once())
+            ->method('find')
+            ->with($keyChain->getIdentifier())
+            ->willReturn($keyChain);
+
         $registration = $this->createTestRegistration();
         $request = $this->createServerRequest('POST', '/example', $this->generateCredentials($registration));
 
         $result = $this->subject->generate(
             $request,
             $this->createResponse(),
-            $registration->getIdentifier()
+            $keyChain->getIdentifier()
         );
 
         $this->assertInstanceOf(ResponseInterface::class, $result);
@@ -97,13 +109,20 @@ class AccessTokenResponseGeneratorTest extends TestCase
 
     public function testGenerateWithScopes(): void
     {
+        $keyChain = $this->createTestKeyChain();
+        $this->keyChainRepositoryMock
+            ->expects($this->once())
+            ->method('find')
+            ->with($keyChain->getIdentifier())
+            ->willReturn($keyChain);
+
         $registration = $this->createTestRegistration();
         $request = $this->createServerRequest('POST', '/example', $this->generateCredentials($registration, ['scope1', 'scope2']));
 
         $result = $this->subject->generate(
             $request,
             $this->createResponse(),
-            $registration->getIdentifier()
+            $keyChain->getIdentifier()
         );
 
         $this->assertInstanceOf(ResponseInterface::class, $result);
@@ -126,7 +145,13 @@ class AccessTokenResponseGeneratorTest extends TestCase
         $this->expectException(OAuthServerException::class);
         $this->expectExceptionMessage('The user credentials were incorrect');
 
-        $registration = $this->createTestRegistration();
+        $keyChain = $this->createTestKeyChain();
+        $this->keyChainRepositoryMock
+            ->expects($this->once())
+            ->method('find')
+            ->with($keyChain->getIdentifier())
+            ->willReturn($keyChain);
+
         $request = $this->createServerRequest(
             'POST',
             '/example',
@@ -138,16 +163,16 @@ class AccessTokenResponseGeneratorTest extends TestCase
             ]
         );
 
-        $result = $this->subject->generate($request, $this->createResponse(), $registration->getIdentifier());
+        $result = $this->subject->generate($request, $this->createResponse(), $keyChain->getIdentifier());
 
         $this->assertInstanceOf(ResponseInterface::class, $result);
         $this->assertEquals(401 , $result->getStatusCode());
     }
 
-    public function testGenerateWitInvalidRegistration(): void
+    public function testGenerateWitInvalidKeyChain(): void
     {
         $this->expectException(OAuthServerException::class);
-        $this->expectExceptionMessage('Invalid registration identifier');
+        $this->expectExceptionMessage('Invalid key chain identifier');
 
         $registration = $this->createTestRegistration();
         $request = $this->createServerRequest('POST', '/example', $this->generateCredentials($registration, ['scope1', 'scope2']));

--- a/tests/Unit/Service/Server/Factory/AuthorizationServerFactoryTest.php
+++ b/tests/Unit/Service/Server/Factory/AuthorizationServerFactoryTest.php
@@ -25,6 +25,7 @@ namespace OAT\Library\Lti1p3Core\Tests\Unit\Service\Server\Factory;
 use Cache\Adapter\PHPArray\ArrayCachePool;
 use InvalidArgumentException;
 use League\OAuth2\Server\AuthorizationServer;
+use OAT\Library\Lti1p3Core\Security\Key\KeyChain;
 use OAT\Library\Lti1p3Core\Service\Server\Factory\AuthorizationServerFactory;
 use OAT\Library\Lti1p3Core\Service\Server\Repository\AccessTokenRepository;
 use OAT\Library\Lti1p3Core\Service\Server\Repository\ClientRepository;
@@ -49,18 +50,24 @@ class AuthorizationServerFactoryTest extends TestCase
         );
     }
 
-    public function testCreateForRegistration(): void
+    public function testCreate(): void
     {
-        $result = $this->subject->createForRegistration($this->createTestRegistration());
+        $result = $this->subject->create($this->createTestKeyChain());
 
         $this->assertInstanceOf(AuthorizationServer::class, $result);
     }
 
-    public function testCreateForRegistrationWithMissingPlatformKeyChain(): void
+    public function testCreateForRegistrationWithMissingPrivateKey(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Missing platform key chain');
+        $this->expectExceptionMessage('Missing private key');
 
-        $this->subject->createForRegistration($this->createTestRegistrationWithoutPlatformKeyChain());
+        $invalidKeyChain = new KeyChain(
+            'identifier',
+            'setName',
+            $publicKey ?? getenv('TEST_KEYS_ROOT_DIR') . '/RSA/public.key'
+        );
+
+        $this->subject->create($invalidKeyChain);
     }
 }


### PR DESCRIPTION
See https://oat-sa.atlassian.net/browse/NEX-1017