### PR TITLE
3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 CHANGELOG
 =========
 
+3.1.0
+-----
+
+* Added PSR15 support for OIDC (init and auth) server components
+* Added possibility to reset the MessagePayloadBuilder to allow multiple generation
+* Added possibility to add several claims at once on the MessagePayloadBuilder
+* Added tool originating DeepLinking response messages stronger validation (on settings data claim)
+* Updated documentation
+
 3.0.0
 -----
 
@@ -15,7 +24,6 @@ CHANGELOG
 * Updated php dependency to >= 7.2.0
 * Updated phpunit dependency to 8.5.8
 * Updated documentation
-
 
 2.4.0
 -----

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
         "nyholm/psr7": "^1.2",
         "psr/cache": "^1.0",
         "psr/http-message": "^1.0",
+        "psr/http-server-handler": "^1.0",
         "psr/log": "^1.1",
         "ramsey/uuid": "^3.9"
     },

--- a/doc/message/platform-originating-messages.md
+++ b/doc/message/platform-originating-messages.md
@@ -177,7 +177,7 @@ die;
 
 ### OIDC initiation redirection automation
 
-This library provides the [OidcInitiationServer](../../src/Security/Oidc/Server/OidcInitiationServer.php) that can be exposed in an application controller to automate a redirect response creation from the [OidcInitiator](../../src/Security/Oidc/OidcInitiator.php) output:
+This library provides the [OidcInitiationServer](../../src/Security/Oidc/Server/OidcInitiationServer.php), implementing the [PSR15 RequestHandlerInterface](https://www.php-fig.org/psr/psr-15/#21-psrhttpserverrequesthandlerinterface), that can be exposed in an application controller to automate a redirect response creation from the [OidcInitiator](../../src/Security/Oidc/OidcInitiator.php) output:
 - it expects a [PSR7 ServerRequestInterface](https://www.php-fig.org/psr/psr-7/#321-psrhttpmessageserverrequestinterface) to handle
 - it will return a [PSR7 ResponseInterface](https://www.php-fig.org/psr/psr-7/#33-psrhttpmessageresponseinterface) instance to make the redirection to the platform.
 
@@ -267,7 +267,7 @@ echo $message->toHtmlRedirectForm();
 
 ### OIDC authentication redirection automation
 
-This library provides the [OidcAuthenticationServer](../../src/Security/Oidc/Server/OidcAuthenticationServer.php) that can be exposed in an application controller to automate a redirect form response creation from the [OidcAuthenticator](../../src/Security/Oidc/OidcAuthenticator.php) output:
+This library provides the [OidcAuthenticationServer](../../src/Security/Oidc/Server/OidcAuthenticationServer.php), implementing the [PSR15 RequestHandlerInterface](https://www.php-fig.org/psr/psr-15/#21-psrhttpserverrequesthandlerinterface), that can be exposed in an application controller to automate a redirect form response creation from the [OidcAuthenticator](../../src/Security/Oidc/OidcAuthenticator.php) output:
 - it expects a [PSR7 ServerRequestInterface](https://www.php-fig.org/psr/psr-7/#321-psrhttpmessageserverrequestinterface) to handle
 - it will return a [PSR7 ResponseInterface](https://www.php-fig.org/psr/psr-7/#33-psrhttpmessageresponseinterface) instance to make the redirection to the tool via a form POST.
 

--- a/doc/quickstart/configuration.md
+++ b/doc/quickstart/configuration.md
@@ -125,9 +125,9 @@ Using JWKS is recommended (but not mandatory):
 Depending on the side you're acting on, you need to provide a `KeyChainInterface` instance that contains a public key and it's associated private key (and passphrase).
 
 For example, if you're acting as a platform:
-- the `$platformKeyChain` have to be given, containing public & private keys (to sign platform originating messages)
-- either the `$toolKeyChain` (with only a public key) or the `$toolJwksUrl` have to be given to validate tool originating messages
+- the `$platformKeyChain` has to be given, containing public & private keys (to sign platform originating messages)
+- either the `$toolKeyChain` (with only a public key) or the `$toolJwksUrl` has to be given to validate tool originating messages
 
 Or, if you're acting as a tool:
-- the `$toolKeyChain` have to be given, containing public & private keys (to sign tool originating messages)
-- either the `$platformKeyChain` (with only a public key) or the `$platformJwksUrl` have to be given to validate platform originating messages
+- the `$toolKeyChain` has to be given, containing public & private keys (to sign tool originating messages)
+- either the `$platformKeyChain` (with only a public key) or the `$platformJwksUrl` has to be given to validate platform originating messages

--- a/src/Message/Payload/Builder/MessagePayloadBuilder.php
+++ b/src/Message/Payload/Builder/MessagePayloadBuilder.php
@@ -60,6 +60,26 @@ class MessagePayloadBuilder implements MessagePayloadBuilderInterface
         $this->signer = $signer ?? new Sha256();
     }
 
+    public function reset(): MessagePayloadBuilderInterface
+    {
+        $this->builder = new Builder();
+
+        return $this;
+    }
+
+    public function withClaims(array $claims): MessagePayloadBuilderInterface
+    {
+        foreach ($claims as $claimName => $claimValue){
+            if (is_a($claimValue, MessagePayloadClaimInterface::class, true)) {
+                $this->withClaim($claimValue);
+            } else {
+                $this->withClaim((string)$claimName, $claimValue);
+            }
+        }
+
+        return $this;
+    }
+
     public function withClaim($claim, $claimValue = null): MessagePayloadBuilderInterface
     {
         if (is_a($claim, MessagePayloadClaimInterface::class, true)) {

--- a/src/Message/Payload/Builder/MessagePayloadBuilderInterface.php
+++ b/src/Message/Payload/Builder/MessagePayloadBuilderInterface.php
@@ -27,6 +27,10 @@ use OAT\Library\Lti1p3Core\Security\Key\KeyChainInterface;
 
 interface MessagePayloadBuilderInterface
 {
+    public function reset(): MessagePayloadBuilderInterface;
+
+    public function withClaims(array $claims): MessagePayloadBuilderInterface;
+
     public function withClaim($claim, $claimValue = null): MessagePayloadBuilderInterface;
 
     public function withMessagePayloadClaims(MessagePayloadInterface $payload): MessagePayloadBuilderInterface;

--- a/src/Security/Oidc/Server/OidcAuthenticationServer.php
+++ b/src/Security/Oidc/Server/OidcAuthenticationServer.php
@@ -25,9 +25,9 @@ namespace OAT\Library\Lti1p3Core\Security\Oidc\Server;
 use Http\Message\ResponseFactory;
 use Nyholm\Psr7\Factory\HttplugFactory;
 use OAT\Library\Lti1p3Core\Security\Oidc\OidcAuthenticator;
-use OAT\Library\Lti1p3Core\Security\Oidc\OidcInitiator;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Throwable;
@@ -35,7 +35,7 @@ use Throwable;
 /**
  * @see https://www.imsglobal.org/spec/security/v1p0/#step-3-authentication-response
  */
-class OidcAuthenticationServer
+class OidcAuthenticationServer implements RequestHandlerInterface
 {
     /** @var OidcAuthenticator */
     private $authenticator;

--- a/src/Security/Oidc/Server/OidcInitiationServer.php
+++ b/src/Security/Oidc/Server/OidcInitiationServer.php
@@ -27,6 +27,7 @@ use Nyholm\Psr7\Factory\HttplugFactory;
 use OAT\Library\Lti1p3Core\Security\Oidc\OidcInitiator;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Throwable;
@@ -34,7 +35,7 @@ use Throwable;
 /**
  * @see https://www.imsglobal.org/spec/security/v1p0/#step-2-authentication-request
  */
-class OidcInitiationServer
+class OidcInitiationServer implements RequestHandlerInterface
 {
     /** @var OidcInitiator */
     private $initiator;

--- a/tests/Unit/Message/Payload/Builder/MessagePayloadBuilderTest.php
+++ b/tests/Unit/Message/Payload/Builder/MessagePayloadBuilderTest.php
@@ -42,6 +42,19 @@ class MessagePayloadBuilderTest extends TestCase
         $this->subject = new MessagePayloadBuilder();
     }
 
+    public function testItCanBeReset(): void
+    {
+        $payload = $this->subject
+            ->withClaim('a', 'b')
+            ->reset()
+            ->withClaim('c', 'd')
+            ->buildMessagePayload($this->createTestKeyChain());
+
+        $this->assertInstanceOf(MessagePayloadInterface::class, $payload);
+        $this->assertNull($payload->getClaim('a'));
+        $this->assertEquals('d', $payload->getClaim('c'));
+    }
+
     public function testItCanGenerateAMessagePayloadWithRegularClaim(): void
     {
         $payload = $this->subject
@@ -61,6 +74,24 @@ class MessagePayloadBuilderTest extends TestCase
             ->buildMessagePayload($this->createTestKeyChain());
 
         $this->assertInstanceOf(MessagePayloadInterface::class, $payload);
+        $this->assertEquals($claim, $payload->getClaim(ResourceLinkClaim::class));
+    }
+
+    public function testItCanGenerateAMessagePayloadFromMultipleMixedClaims(): void
+    {
+        $claim = new ResourceLinkClaim('id');
+
+        $claims = [
+            'a' => 'b',
+            $claim
+        ];
+
+        $payload = $this->subject
+            ->withClaims($claims)
+            ->buildMessagePayload($this->createTestKeyChain());
+
+        $this->assertInstanceOf(MessagePayloadInterface::class, $payload);
+        $this->assertEquals('b', $payload->getClaim('a'));
         $this->assertEquals($claim, $payload->getClaim(ResourceLinkClaim::class));
     }
 


### PR DESCRIPTION
* Added PSR15 support for OIDC (init and auth) server components
* Added possibility to reset the MessagePayloadBuilder to allow multiple generation
* Added possibility to add several claims at once on the MessagePayloadBuilder
* Added tool originating DeepLinking response messages stronger validation (on settings data claim)
* Updated documentation

target release: `3.1.0`