### PR TITLE
Fixed DeepLinkingSettingsClaim boolean properties handling (select multple, auto create)

### DIFF
--- a/src/Message/Payload/Claim/DeepLinkingSettingsClaim.php
+++ b/src/Message/Payload/Claim/DeepLinkingSettingsClaim.php
@@ -155,11 +155,24 @@ class DeepLinkingSettingsClaim implements MessagePayloadClaimInterface
             $claimData['accept_types'],
             $claimData['accept_presentation_document_targets'],
             $claimData['accept_media_types'] ?? null,
-            $claimData['accept_multiple'] ?? true,
-            $claimData['auto_create'] ?? false,
+            self::extractBooleanValue($claimData, 'accept_multiple', true),
+            self::extractBooleanValue($claimData, 'auto_create', false),
             $claimData['title'] ?? null,
             $claimData['text'] ?? null,
             $claimData['data'] ?? null
         );
+    }
+
+    private static function extractBooleanValue(array $claimData, string $key, bool $defaultValue): bool
+    {
+        if (!array_key_exists($key, $claimData)) {
+            return $defaultValue;
+        }
+
+        if (is_string($claimData[$key])) {
+            return 'true' === $claimData[$key];
+        } else {
+            return (bool) $claimData[$key];
+        }
     }
 }

--- a/tests/Unit/Message/Payload/Claim/DeepLinkingSettingsClaimTest.php
+++ b/tests/Unit/Message/Payload/Claim/DeepLinkingSettingsClaimTest.php
@@ -107,4 +107,34 @@ class DeepLinkingSettingsClaimTest extends TestCase
         $this->assertEquals('text', $denormalisation->getText());
         $this->assertEquals('data', $denormalisation->getData());
     }
+
+    public function testDenormalisationWithStringBooleans(): void
+    {
+        $denormalisation = DeepLinkingSettingsClaim::denormalize([
+            'deep_link_return_url' => 'deepLinkingReturnUrl',
+            'accept_types' => ['ltiResourceLink', 'link', 'image'],
+            'accept_presentation_document_targets' => ['window'],
+            'accept_media_types' => 'text/html',
+            'accept_multiple' => 'false',
+            'auto_create' => 'true',
+        ]);
+
+        $this->assertInstanceOf(DeepLinkingSettingsClaim::class, $denormalisation);
+        $this->assertFalse($denormalisation->shouldAcceptMultiple());
+        $this->assertTrue($denormalisation->shouldAutoCreate());
+    }
+
+    public function testDenormalisationWithMissingBooleans(): void
+    {
+        $denormalisation = DeepLinkingSettingsClaim::denormalize([
+            'deep_link_return_url' => 'deepLinkingReturnUrl',
+            'accept_types' => ['ltiResourceLink', 'link', 'image'],
+            'accept_presentation_document_targets' => ['window'],
+            'accept_media_types' => 'text/html',
+        ]);
+
+        $this->assertInstanceOf(DeepLinkingSettingsClaim::class, $denormalisation);
+        $this->assertTrue($denormalisation->shouldAcceptMultiple());
+        $this->assertFalse($denormalisation->shouldAutoCreate());
+    }
 }


### PR DESCRIPTION
Fixed DeepLinkingSettingsClaim boolean properties handling (select multple, auto create)

target release: `3.1.1`