### PR TITLE
Minor bug: If jwks key is not found in the cache, check for new keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+3.2.1
+-----
+
+* Added fallback to JWKS lookup to check URL if key is not found in cache
+
 3.2.0
 -----
 


### PR DESCRIPTION
Hi!

A client of mine uses this wonderful library and bundle - thanks so much for creating it and compliments on its incredible quality.

So far, we've only experienced this one minor issue while using it. This PR solves a problem where the jwks cache is being stored for 24 hours, but the platform is rotating keys every 1 hour. The result is that the cache *is* still fresh, but new keys could not be found there.

Please let me know if you need any other information :). We are currently disabling the cache entirely for this service as a work around.

Cheers!