### PR TITLE
Fixed lcobucci/jwt dependency to version 3.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+3.2.2
+-----
+
+* Fixed lcobucci/jwt dependency to version 3.3.3
+
 3.2.1
 -----
 

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "ext-json": "*",
         "codercat/jwk-to-pem": "^0.0.3",
         "guzzlehttp/guzzle": "^6.5",
-        "lcobucci/jwt": "^3.3",
+        "lcobucci/jwt": "3.3.3",
         "league/oauth2-server": "^8.1",
         "nesbot/carbon": "^2.31",
         "nyholm/psr7": "^1.2",


### PR DESCRIPTION
* Fixed lcobucci/jwt dependency to version 3.3.3

target release: `3.2.2`