### PR TITLE
Fix/launch with user claims

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ php:
   - 7.2
   - 7.3
   - 7.4
+  - 8.0
 
 before_script:
   - composer self-update && composer install --no-interaction

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ php:
   - 7.2
   - 7.3
   - 7.4
-  - 8.0
 
 before_script:
   - composer self-update && composer install --no-interaction

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+3.3.1
+-----
+
+* Fixed possibility to provide user identity claims during platform originating messages launch generation
+* Fixed issue [#74](https://github.com/oat-sa/lib-lti1p3-core/issues/74)
+
 3.3.0
 -----
 
@@ -47,7 +53,7 @@ CHANGELOG
 * Added new core message layer foundations (new interfaces and abstractions)
 * Added core tool originating message layer (builder, validator, result) based on new foundations
 * Reworked (breaking changes) core platform originating message layer (builder, validator, result) based on new foundations
-* Fixed core service client audience for access token requests
+* Fixed issue [#46](https://github.com/oat-sa/lib-lti1p3-core/issues/46)
 * Updated php dependency to >= 7.2.0
 * Updated phpunit dependency to 8.5.8
 * Updated documentation

--- a/src/Message/Launch/Builder/AbstractLaunchBuilder.php
+++ b/src/Message/Launch/Builder/AbstractLaunchBuilder.php
@@ -39,13 +39,17 @@ abstract class AbstractLaunchBuilder
         $this->builder = $builder ?? new MessagePayloadBuilder();
     }
 
-    protected function applyOptionalClaims(array $optionalClaims): self
+    protected function applyOptionalClaims(array $optionalClaims, array $exclusions = []): self
     {
         foreach ($optionalClaims as $claimName => $claim) {
             if ($claim instanceof MessagePayloadClaimInterface) {
-                $this->builder->withClaim($claim);
+                if (!in_array($claim->getClaimName(), $exclusions)) {
+                    $this->builder->withClaim($claim);
+                }
             } else {
-                $this->builder->withClaim($claimName, $claim);
+                if (!in_array($claimName, $exclusions)) {
+                    $this->builder->withClaim($claimName, $claim);
+                }
             }
         }
 

--- a/src/Message/Launch/Builder/PlatformOriginatingLaunchBuilder.php
+++ b/src/Message/Launch/Builder/PlatformOriginatingLaunchBuilder.php
@@ -55,7 +55,19 @@ class PlatformOriginatingLaunchBuilder extends AbstractLaunchBuilder
             ->withClaim(LtiMessagePayloadInterface::CLAIM_LTI_ROLES, $roles)
             ->withClaim(LtiMessagePayloadInterface::CLAIM_REGISTRATION_ID, $registration->getIdentifier());
 
-        $this->applyOptionalClaims($optionalClaims);
+        $this->applyOptionalClaims(
+            $optionalClaims,
+            [
+                LtiMessagePayloadInterface::CLAIM_SUB,
+                LtiMessagePayloadInterface::CLAIM_USER_NAME,
+                LtiMessagePayloadInterface::CLAIM_USER_EMAIL,
+                LtiMessagePayloadInterface::CLAIM_USER_GIVEN_NAME,
+                LtiMessagePayloadInterface::CLAIM_USER_FAMILY_NAME,
+                LtiMessagePayloadInterface::CLAIM_USER_MIDDLE_NAME,
+                LtiMessagePayloadInterface::CLAIM_USER_LOCALE,
+                LtiMessagePayloadInterface::CLAIM_USER_PICTURE,
+            ]
+        );
 
         $ltiMessageHintPayload = $this->builder->buildMessagePayload($registration->getPlatformKeyChain());
 

--- a/src/Message/Payload/Builder/MessagePayloadBuilder.php
+++ b/src/Message/Payload/Builder/MessagePayloadBuilder.php
@@ -92,11 +92,15 @@ class MessagePayloadBuilder implements MessagePayloadBuilderInterface
         return $this;
     }
 
-    public function withMessagePayloadClaims(MessagePayloadInterface $payload): MessagePayloadBuilderInterface
-    {
+    public function withMessagePayloadClaims(
+        MessagePayloadInterface $payload,
+        array $exclusions = []
+    ): MessagePayloadBuilderInterface {
         /** @var Claim $claim */
         foreach ($payload->getToken()->getClaims() as $claim) {
-            $this->builder->withClaim($claim->getName(), $claim->getValue());
+            if (!in_array($claim->getName(), $exclusions)) {
+                $this->builder->withClaim($claim->getName(), $claim->getValue());
+            }
         }
 
         return $this;

--- a/src/Message/Payload/Builder/MessagePayloadBuilderInterface.php
+++ b/src/Message/Payload/Builder/MessagePayloadBuilderInterface.php
@@ -33,7 +33,10 @@ interface MessagePayloadBuilderInterface
 
     public function withClaim($claim, $claimValue = null): MessagePayloadBuilderInterface;
 
-    public function withMessagePayloadClaims(MessagePayloadInterface $payload): MessagePayloadBuilderInterface;
+    public function withMessagePayloadClaims(
+        MessagePayloadInterface $payload,
+        array $exclusions = []
+    ): MessagePayloadBuilderInterface;
 
     public function buildMessagePayload(KeyChainInterface $keyChain): MessagePayloadInterface;
 }

--- a/src/Message/Payload/LtiMessagePayload.php
+++ b/src/Message/Payload/LtiMessagePayload.php
@@ -126,14 +126,14 @@ class LtiMessagePayload extends MessagePayload implements LtiMessagePayloadInter
         }
 
         return new UserIdentity(
-            (string)$this->getClaim('sub'),
-            $this->getClaim('name'),
-            $this->getClaim('email'),
-            $this->getClaim('given_name'),
-            $this->getClaim('family_name'),
-            $this->getClaim('middle_name'),
-            $this->getClaim('locale'),
-            $this->getClaim('picture')
+            (string)$this->getClaim(self::CLAIM_SUB),
+            $this->getClaim(self::CLAIM_USER_NAME),
+            $this->getClaim(self::CLAIM_USER_EMAIL),
+            $this->getClaim(self::CLAIM_USER_GIVEN_NAME),
+            $this->getClaim(self::CLAIM_USER_FAMILY_NAME),
+            $this->getClaim(self::CLAIM_USER_MIDDLE_NAME),
+            $this->getClaim(self::CLAIM_USER_LOCALE),
+            $this->getClaim(self::CLAIM_USER_PICTURE)
         );
     }
 

--- a/src/Message/Payload/MessagePayloadInterface.php
+++ b/src/Message/Payload/MessagePayloadInterface.php
@@ -45,6 +45,13 @@ interface MessagePayloadInterface
     public const CLAIM_REGISTRATION_ID = 'registration_id';
     public const CLAIM_NONCE = 'nonce';
     public const CLAIM_PARAMETERS = 'parameters';
+    public const CLAIM_USER_NAME ='name';
+    public const CLAIM_USER_EMAIL = 'email';
+    public const CLAIM_USER_GIVEN_NAME ='given_name';
+    public const CLAIM_USER_FAMILY_NAME ='family_name';
+    public const CLAIM_USER_MIDDLE_NAME ='middle_name';
+    public const CLAIM_USER_LOCALE ='locale';
+    public const CLAIM_USER_PICTURE ='picture';
 
     public function getToken(): Token;
 

--- a/src/Security/Oidc/OidcAuthenticator.php
+++ b/src/Security/Oidc/OidcAuthenticator.php
@@ -107,7 +107,19 @@ class OidcAuthenticator
             }
 
             $this->builder
-                ->withMessagePayloadClaims($originalPayload)
+                ->withMessagePayloadClaims(
+                    $originalPayload,
+                    [
+                        LtiMessagePayloadInterface::CLAIM_SUB,
+                        LtiMessagePayloadInterface::CLAIM_USER_NAME,
+                        LtiMessagePayloadInterface::CLAIM_USER_EMAIL,
+                        LtiMessagePayloadInterface::CLAIM_USER_GIVEN_NAME,
+                        LtiMessagePayloadInterface::CLAIM_USER_FAMILY_NAME,
+                        LtiMessagePayloadInterface::CLAIM_USER_MIDDLE_NAME,
+                        LtiMessagePayloadInterface::CLAIM_USER_LOCALE,
+                        LtiMessagePayloadInterface::CLAIM_USER_PICTURE,
+                    ]
+                )
                 ->withClaim(LtiMessagePayloadInterface::CLAIM_ISS, $registration->getPlatform()->getAudience())
                 ->withClaim(LtiMessagePayloadInterface::CLAIM_AUD, $registration->getClientId());
 

--- a/src/User/UserIdentity.php
+++ b/src/User/UserIdentity.php
@@ -21,6 +21,8 @@ declare(strict_types=1);
 
 namespace OAT\Library\Lti1p3Core\User;
 
+use OAT\Library\Lti1p3Core\Message\Payload\MessagePayloadInterface;
+
 /**
  * @see http://www.imsglobal.org/spec/lti/v1p3/#user-identity-claims-0
  */
@@ -127,15 +129,18 @@ class UserIdentity implements UserIdentityInterface
 
     public function normalize(): array
     {
-        return array_filter([
-            'sub' => $this->getIdentifier(),
-            'name' => $this->getName(),
-            'email' => $this->getEmail(),
-            'given_name' => $this->getGivenName(),
-            'family_name' => $this->getFamilyName(),
-            'middle_name' => $this->getMiddleName(),
-            'locale' => $this->getLocale(),
-            'picture' => $this->getPicture(),
-        ] + $this->additionalProperties);
+        return array_filter(
+            [
+                MessagePayloadInterface::CLAIM_SUB => $this->getIdentifier(),
+                MessagePayloadInterface::CLAIM_USER_NAME => $this->getName(),
+                MessagePayloadInterface::CLAIM_USER_EMAIL => $this->getEmail(),
+                MessagePayloadInterface::CLAIM_USER_GIVEN_NAME => $this->getGivenName(),
+                MessagePayloadInterface::CLAIM_USER_FAMILY_NAME => $this->getFamilyName(),
+                MessagePayloadInterface::CLAIM_USER_MIDDLE_NAME => $this->getMiddleName(),
+                MessagePayloadInterface::CLAIM_USER_LOCALE => $this->getLocale(),
+                MessagePayloadInterface::CLAIM_USER_PICTURE => $this->getPicture(),
+            ]
+            + $this->additionalProperties
+        );
     }
 }

--- a/tests/Traits/DomainTestingTrait.php
+++ b/tests/Traits/DomainTestingTrait.php
@@ -65,7 +65,7 @@ trait DomainTestingTrait
     private function createTestTool(
         string $identifier = 'toolIdentifier',
         string $name = 'toolName',
-        string $audience = 'platformAudience',
+        string $audience = 'toolAudience',
         string $oidcInitiationUrl = 'http://tool.com/oidc-init',
         string $launchUrl = 'http://tool.com/launch',
         string $deepLinkingUrl = 'http://tool.com/deep-launch'

--- a/tests/Unit/Message/Launch/Builder/PlatformOriginatingLaunchBuilderTest.php
+++ b/tests/Unit/Message/Launch/Builder/PlatformOriginatingLaunchBuilderTest.php
@@ -99,14 +99,14 @@ class PlatformOriginatingLaunchBuilderTest extends TestCase
             [],
             [
                 'a' => 'b',
-                'sub' => 'sub',
-                'name' => 'name',
-                'email' => 'email',
-                'given_name' => 'given_name',
-                'family_name' => 'family_name',
-                'middle_name' => 'middle_name',
-                'locale' => 'locale',
-                'picture' => 'picture',
+                LtiMessagePayloadInterface::CLAIM_SUB => 'sub',
+                LtiMessagePayloadInterface::CLAIM_USER_NAME => 'name',
+                LtiMessagePayloadInterface::CLAIM_USER_EMAIL => 'email',
+                LtiMessagePayloadInterface::CLAIM_USER_GIVEN_NAME => 'given_name',
+                LtiMessagePayloadInterface::CLAIM_USER_FAMILY_NAME => 'family_name',
+                LtiMessagePayloadInterface::CLAIM_USER_MIDDLE_NAME => 'middle_name',
+                LtiMessagePayloadInterface::CLAIM_USER_LOCALE => 'locale',
+                LtiMessagePayloadInterface::CLAIM_USER_PICTURE => 'picture',
             ]
         );
 
@@ -118,14 +118,14 @@ class PlatformOriginatingLaunchBuilderTest extends TestCase
 
         $this->assertEquals('b', $ltiMessageHintToken->getClaim('a'));
 
-        $this->assertFalse($ltiMessageHintToken->hasClaim('sub'));
-        $this->assertFalse($ltiMessageHintToken->hasClaim('name'));
-        $this->assertFalse($ltiMessageHintToken->hasClaim('email'));
-        $this->assertFalse($ltiMessageHintToken->hasClaim('given_name'));
-        $this->assertFalse($ltiMessageHintToken->hasClaim('family_name'));
-        $this->assertFalse($ltiMessageHintToken->hasClaim('middle_name'));
-        $this->assertFalse($ltiMessageHintToken->hasClaim('locale'));
-        $this->assertFalse($ltiMessageHintToken->hasClaim('picture'));
+        $this->assertFalse($ltiMessageHintToken->hasClaim(LtiMessagePayloadInterface::CLAIM_SUB));
+        $this->assertFalse($ltiMessageHintToken->hasClaim(LtiMessagePayloadInterface::CLAIM_USER_NAME));
+        $this->assertFalse($ltiMessageHintToken->hasClaim(LtiMessagePayloadInterface::CLAIM_USER_EMAIL));
+        $this->assertFalse($ltiMessageHintToken->hasClaim(LtiMessagePayloadInterface::CLAIM_USER_GIVEN_NAME));
+        $this->assertFalse($ltiMessageHintToken->hasClaim(LtiMessagePayloadInterface::CLAIM_USER_FAMILY_NAME));
+        $this->assertFalse($ltiMessageHintToken->hasClaim(LtiMessagePayloadInterface::CLAIM_USER_MIDDLE_NAME));
+        $this->assertFalse($ltiMessageHintToken->hasClaim(LtiMessagePayloadInterface::CLAIM_USER_LOCALE));
+        $this->assertFalse($ltiMessageHintToken->hasClaim(LtiMessagePayloadInterface::CLAIM_USER_PICTURE));
     }
 
     public function testBuildPlatformOriginatingLaunchErrorOnInvalidDeploymentId(): void

--- a/tests/Unit/Security/Oidc/OidcAuthenticatorTest.php
+++ b/tests/Unit/Security/Oidc/OidcAuthenticatorTest.php
@@ -152,7 +152,7 @@ class OidcAuthenticatorTest extends TestCase
         $this->subject->authenticate($request);
     }
 
-    public function testAuthenticationFailureOnAuthenticationFailure(): void
+    public function testAuthenticationFailureOnUserAuthenticationFailure(): void
     {
         $this->expectException(LtiException::class);
         $this->expectExceptionMessage('User authentication failure');

--- a/tests/Unit/Security/Oidc/OidcAuthenticatorTest.php
+++ b/tests/Unit/Security/Oidc/OidcAuthenticatorTest.php
@@ -25,6 +25,8 @@ namespace OAT\Library\Lti1p3Core\Tests\Unit\Security\Oidc;
 use Carbon\Carbon;
 use Lcobucci\JWT\Signer\Hmac\Sha384;
 use OAT\Library\Lti1p3Core\Exception\LtiException;
+use OAT\Library\Lti1p3Core\Message\LtiMessageInterface;
+use OAT\Library\Lti1p3Core\Message\Payload\LtiMessagePayloadInterface;
 use OAT\Library\Lti1p3Core\Message\Payload\MessagePayloadInterface;
 use OAT\Library\Lti1p3Core\Registration\RegistrationRepositoryInterface;
 use OAT\Library\Lti1p3Core\Security\Oidc\OidcAuthenticator;
@@ -56,6 +58,109 @@ class OidcAuthenticatorTest extends TestCase
         $this->authenticatorMock = $this->createMock(UserAuthenticatorInterface::class);
 
         $this->subject= new OidcAuthenticator($this->repositoryMock, $this->authenticatorMock);
+    }
+
+    public function testAuthenticationSuccess(): void
+    {
+        $this->subject= new OidcAuthenticator($this->createTestRegistrationRepository(), $this->createTestUserAuthenticator());
+
+        $registration = $this->createTestRegistration();
+
+        $messageHint = $this->buildJwt(
+            [
+                MessagePayloadInterface::HEADER_KID => $registration->getToolKeyChain()->getIdentifier()
+            ],
+            [
+                LtiMessagePayloadInterface::CLAIM_LTI_TARGET_LINK_URI => 'target_link_uri',
+                LtiMessagePayloadInterface::CLAIM_REGISTRATION_ID => $registration->getIdentifier(),
+
+            ],
+            $registration->getToolKeyChain()->getPrivateKey()
+        );
+
+        $request = $this->createServerRequest(
+            'GET',
+            sprintf('http://platform.com/init?%s', http_build_query([
+                'login_hint' => 'login_hint',
+                'lti_message_hint' => $messageHint->__toString(),
+                'state' => 'state'
+            ]))
+        );
+
+        $result = $this->subject->authenticate($request);
+
+        $this->assertInstanceOf(LtiMessageInterface::class, $result);
+
+        $this->assertTrue($result->hasParameter('id_token'));
+        $this->assertTrue($result->hasParameter('state'));
+
+        $idToken = $this->parseJwt($result->getParameter('id_token'));
+
+        $this->assertTrue($this->verifyJwt($idToken, $registration->getPlatformKeyChain()->getPublicKey()));
+
+        $this->assertEquals(
+            'target_link_uri',
+            $idToken->getClaim(LtiMessagePayloadInterface::CLAIM_LTI_TARGET_LINK_URI)
+        );
+        $this->assertEquals(
+            $registration->getIdentifier(),
+            $idToken->getClaim(LtiMessagePayloadInterface::CLAIM_REGISTRATION_ID)
+        );
+    }
+
+    public function testAuthenticationSuccessWithUserIdentityClaimsExclusion(): void
+    {
+        $this->subject= new OidcAuthenticator($this->createTestRegistrationRepository(), $this->createTestUserAuthenticator());
+
+        $registration = $this->createTestRegistration();
+
+        $messageHint = $this->buildJwt(
+            [
+                MessagePayloadInterface::HEADER_KID => $registration->getToolKeyChain()->getIdentifier()
+            ],
+            [
+                LtiMessagePayloadInterface::CLAIM_LTI_TARGET_LINK_URI => 'target_link_uri',
+                LtiMessagePayloadInterface::CLAIM_REGISTRATION_ID => $registration->getIdentifier(),
+                LtiMessagePayloadInterface::CLAIM_SUB => 'sub',
+                LtiMessagePayloadInterface::CLAIM_USER_NAME => 'name',
+                LtiMessagePayloadInterface::CLAIM_USER_EMAIL => 'email',
+                LtiMessagePayloadInterface::CLAIM_USER_GIVEN_NAME => 'given_name',
+                LtiMessagePayloadInterface::CLAIM_USER_FAMILY_NAME => 'family_name',
+                LtiMessagePayloadInterface::CLAIM_USER_MIDDLE_NAME => 'middle_name',
+                LtiMessagePayloadInterface::CLAIM_USER_LOCALE => 'locale',
+                LtiMessagePayloadInterface::CLAIM_USER_PICTURE => 'picture',
+
+            ],
+            $registration->getToolKeyChain()->getPrivateKey()
+        );
+
+        $request = $this->createServerRequest(
+            'GET',
+            sprintf('http://platform.com/init?%s', http_build_query([
+                'login_hint' => 'login_hint',
+                'lti_message_hint' => $messageHint->__toString(),
+                'state' => 'state'
+            ]))
+        );
+
+        $result = $this->subject->authenticate($request);
+
+        $this->assertInstanceOf(LtiMessageInterface::class, $result);
+
+        $this->assertTrue($result->hasParameter('id_token'));
+
+        $idToken = $this->parseJwt($result->getParameter('id_token'));
+
+        $this->assertTrue($this->verifyJwt($idToken, $registration->getPlatformKeyChain()->getPublicKey()));
+
+        $this->assertEquals('userIdentifier', $idToken->getClaim(LtiMessagePayloadInterface::CLAIM_SUB));
+        $this->assertEquals('userName', $idToken->getClaim(LtiMessagePayloadInterface::CLAIM_USER_NAME));
+        $this->assertEquals('userEmail', $idToken->getClaim(LtiMessagePayloadInterface::CLAIM_USER_EMAIL));
+        $this->assertEquals('userGivenName', $idToken->getClaim(LtiMessagePayloadInterface::CLAIM_USER_GIVEN_NAME));
+        $this->assertEquals('userFamilyName', $idToken->getClaim(LtiMessagePayloadInterface::CLAIM_USER_FAMILY_NAME));
+        $this->assertEquals('userMiddleName', $idToken->getClaim(LtiMessagePayloadInterface::CLAIM_USER_MIDDLE_NAME));
+        $this->assertEquals('userLocale', $idToken->getClaim(LtiMessagePayloadInterface::CLAIM_USER_LOCALE));
+        $this->assertEquals('userPicture', $idToken->getClaim(LtiMessagePayloadInterface::CLAIM_USER_PICTURE));
     }
 
     public function testAuthenticationFailureOnExpiredMessageHint(): void


### PR DESCRIPTION
* Fixed possibility to provide user identity claims during platform originating messages launch generation
* Fixed issue [#74](https://github.com/oat-sa/lib-lti1p3-core/issues/74)

Target release: `3.3.1`