### PR TITLE
Allow use of ramsey/uuid version 4 in downstream projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+3.3.1
+-----
+
+* Updated the version of ramsey/uuid dependency to allow the use of version 4 
+
 3.3.0
 -----
 

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "psr/http-message": "^1.0",
         "psr/http-server-handler": "^1.0",
         "psr/log": "^1.1",
-        "ramsey/uuid": "^3.9"
+        "ramsey/uuid": "^3.9 || ^4"
     },
     "require-dev": {
         "cache/array-adapter": "^1.0",


### PR DESCRIPTION
Thank you very much for your efforts of maintaining this library!

We use it in our project, which currently requires the use of version 4 of `ramsey/uuid`. Unfortunately, this is in conflict with the declared `^3.9` version in this library. Inspecting the usage of `ramsey/uuid`in this library the upgrade can de done without problems. 

Following the tips in the [upgrade guide of `ramsey/uuid`](https://uuid.ramsey.dev/en/latest/upgrading/3-to-4.html) both versions can be listed to avoid a forced update in downstream projects. 

Please let me know if you need any additional information or tests.