### PR TITLE
Added possibility for service client to bust invalid cached token and auto retry to get granted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+4.1.0
+-----
+
+* Added invalid access token cache busting on 401 LTI service response (with auto retry)
+
 4.0.0
 -----
 

--- a/src/Service/Client/ServiceClient.php
+++ b/src/Service/Client/ServiceClient.php
@@ -80,7 +80,8 @@ class ServiceClient implements ServiceClientInterface
                 [
                     'headers' => [
                         'Authorization' => sprintf('Bearer %s', $this->getAccessToken($registration, $scopes))
-                    ]
+                    ],
+                    'http_errors' => true
                 ]
             );
 

--- a/tests/Unit/Service/Client/ServiceClientTest.php
+++ b/tests/Unit/Service/Client/ServiceClientTest.php
@@ -440,7 +440,7 @@ class ServiceClientTest extends TestCase
                         $this->createMock(ServerRequestInterface::class),
                         $this->createResponse('internal server error', 500)
                     )
-                ),
+                )
             );
 
         $this->subject->request($this->registration, 'GET', 'http://example.com');

--- a/tests/Unit/Service/Client/ServiceClientTest.php
+++ b/tests/Unit/Service/Client/ServiceClientTest.php
@@ -436,7 +436,7 @@ class ServiceClientTest extends TestCase
                 $this->createResponse(json_encode(['access_token'=> 'access_token', 'expires_in' => 3600])),
                 $this->throwException(
                     new ClientException(
-                        'invalid token',
+                        'internal server error',
                         $this->createMock(ServerRequestInterface::class),
                         $this->createResponse('internal server error', 500)
                     )

--- a/tests/Unit/Service/Client/ServiceClientTest.php
+++ b/tests/Unit/Service/Client/ServiceClientTest.php
@@ -101,7 +101,8 @@ class ServiceClientTest extends TestCase
                     'GET',
                     'http://example.com',
                     [
-                        'headers' => ['Authorization' => 'Bearer access_token']
+                        'headers' => ['Authorization' => 'Bearer access_token'],
+                        'http_errors' => true
                     ]
                 ]
             )
@@ -142,7 +143,8 @@ class ServiceClientTest extends TestCase
                     'GET',
                     'http://example.com',
                     [
-                        'headers' => ['Authorization' => 'Bearer access_token']
+                        'headers' => ['Authorization' => 'Bearer access_token'],
+                        'http_errors' => true
                     ]
                 ]
             )
@@ -174,7 +176,8 @@ class ServiceClientTest extends TestCase
                 'GET',
                 'http://example.com',
                 [
-                    'headers' => ['Authorization' => 'Bearer cached_access_token']
+                    'headers' => ['Authorization' => 'Bearer cached_access_token'],
+                    'http_errors' => true
                 ]
             )
             ->willReturn(
@@ -202,7 +205,8 @@ class ServiceClientTest extends TestCase
                 'GET',
                 'http://example.com',
                 [
-                    'headers' => ['Authorization' => 'Bearer cached_access_token']
+                    'headers' => ['Authorization' => 'Bearer cached_access_token'],
+                    'http_errors' => true
                 ]
             )
             ->willReturn(
@@ -231,7 +235,8 @@ class ServiceClientTest extends TestCase
                     'GET',
                     'http://example.com',
                     [
-                        'headers' => ['Authorization' => 'Bearer invalid_access_token']
+                        'headers' => ['Authorization' => 'Bearer invalid_access_token'],
+                        'http_errors' => true
                     ]
                 ],
                 [
@@ -250,7 +255,8 @@ class ServiceClientTest extends TestCase
                     'GET',
                     'http://example.com',
                     [
-                        'headers' => ['Authorization' => 'Bearer valid_access_token']
+                        'headers' => ['Authorization' => 'Bearer valid_access_token'],
+                        'http_errors' => true
                     ]
                 ]
             )
@@ -391,7 +397,8 @@ class ServiceClientTest extends TestCase
                     'GET',
                     'http://example.com',
                     [
-                        'headers' => ['Authorization' => 'Bearer access_token']
+                        'headers' => ['Authorization' => 'Bearer access_token'],
+                        'http_errors' => true
                     ]
                 ]
             )
@@ -428,7 +435,8 @@ class ServiceClientTest extends TestCase
                     'GET',
                     'http://example.com',
                     [
-                        'headers' => ['Authorization' => 'Bearer access_token']
+                        'headers' => ['Authorization' => 'Bearer access_token'],
+                        'http_errors' => true
                     ]
                 ]
             )


### PR DESCRIPTION
feat: added possibility for service client to bust invalid cached token (401) and auto retry to get granted before next request

target release: `4.1.0`