### PR TITLE
feat: version 6.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 CHANGELOG
 =========
 
+6.0.0
+-----
+
+* Added [migration guide](https://github.com/oat-sa/lib-lti1p3-core/wiki/Migration-from-5.x-to-6.x) to document breaking changes and migration steps
+* Added LaunchValidatorInterface, PlatformLaunchValidatorInterface and ToolLaunchValidatorInterface
+* Added AccessTokenResponseGeneratorInterface
+* Added RequestAccessTokenValidatorInterface and RequestAccessTokenValidationResultInterface
+* Moved PlatformLaunchValidator in Platform sub namespace  
+* Moved ToolLaunchValidator in Tool sub namespace  
+* Updated LtiServiceServerRequestHandlerInterface signature
+* Updated documentation
+
 5.0.1
 -----
 

--- a/doc/message/platform-originating-messages.md
+++ b/doc/message/platform-originating-messages.md
@@ -316,16 +316,16 @@ You can find below required steps to validate a platform originating message lau
 
 As a tool, you'll receive an HTTP request containing the launch message after OIDC flow completion.
 
-The [ToolLaunchValidator](../../src/Message/Launch/Validator/ToolLaunchValidator.php) can be used for this:
+The [ToolLaunchValidator](../../src/Message/Launch/Validator/Tool/ToolLaunchValidator.php) can be used for this:
 - it requires a registration repository and a nonce repository implementations [as explained here](../quickstart/interfaces.md)
 - it expects a [PSR7 ServerRequestInterface](https://www.php-fig.org/psr/psr-7/#321-psrhttpmessageserverrequestinterface) to validate
-- it will output a [LaunchValidationResult](../../src/Message/Launch/Validator/Result/LaunchValidationResult.php) representing the launch validation, the related registration and the message payload itself.
+- it will output a [LaunchValidationResultInterface](../../src/Message/Launch/Validator/Result/LaunchValidationResultInterface.php) representing the launch validation, the related registration and the message payload itself.
 
 For example:
 ```php
 <?php
 
-use OAT\Library\Lti1p3Core\Message\Launch\Validator\ToolLaunchValidator;
+use OAT\Library\Lti1p3Core\Message\Launch\Validator\Tool\ToolLaunchValidator;
 use OAT\Library\Lti1p3Core\Registration\RegistrationRepositoryInterface;
 use OAT\Library\Lti1p3Core\Security\Nonce\NonceRepositoryInterface;
 use Psr\Http\Message\ServerRequestInterface;

--- a/doc/message/tool-originating-messages.md
+++ b/doc/message/tool-originating-messages.md
@@ -73,16 +73,16 @@ You can find below required steps to validate a tool originating message launch,
 
 As a platform, you'll receive an HTTP request containing the launch message.
 
-The [PlatformLaunchValidator](../../src/Message/Launch/Validator/PlatformLaunchValidator.php) can be used for this:
+The [PlatformLaunchValidator](../../src/Message/Launch/Validator/Platform/PlatformLaunchValidator.php) can be used for this:
 - it requires a registration repository and a nonce repository implementations [as explained here](../quickstart/interfaces.md)
 - it expects a [PSR7 ServerRequestInterface](https://www.php-fig.org/psr/psr-7/#321-psrhttpmessageserverrequestinterface) to validate
-- it will output a [LaunchValidationResult](../../src/Message/Launch/Validator/Result/LaunchValidationResult.php) representing the launch validation, the related registration and the message payload itself.
+- it will output a [LaunchValidationResultInterface](../../src/Message/Launch/Validator/Result/LaunchValidationResultInterface.php) representing the launch validation, the related registration and the message payload itself.
 
 For example:
 ```php
 <?php
 
-use OAT\Library\Lti1p3Core\Message\Launch\Validator\PlatformLaunchValidator;
+use OAT\Library\Lti1p3Core\Message\Launch\Validator\PLatform\PlatformLaunchValidator;
 use OAT\Library\Lti1p3Core\Registration\RegistrationRepositoryInterface;
 use OAT\Library\Lti1p3Core\Security\Nonce\NonceRepositoryInterface;
 use Psr\Http\Message\ServerRequestInterface;

--- a/doc/quickstart/interfaces.md
+++ b/doc/quickstart/interfaces.md
@@ -142,7 +142,19 @@ $fetcher = new class implements JwksFetcherInterface
 - it is recommended to put in cache the JWKS endpoint responses, to improve performances since they don't change often. Your implementation can then rely on a cache by example.
 - the ready to use [JwksFetcher](../../src/Security/Jwks/Fetcher/JwksFetcher.php) works with a [guzzle](http://docs.guzzlephp.org/en/stable/) client to request JWKS data, a [PSR6 cache](https://www.php-fig.org/psr/psr-6/#cacheitempoolinterface) to cache them, and a [PSR3 logger](https://www.php-fig.org/psr/psr-3/#3-psrlogloggerinterface) to log this process.
 
-### LTI Service client interface
+### LTI platform message launch validator interface
+
+**Default implementation**: [PlatformLaunchValidator](../../src/Message/Launch/Validator/Platform/PlatformLaunchValidator.php)
+
+To customise platform message launch validation, an implementation of the [PlatformLaunchValidatorInterface](../../src/Message/Launch/Validator/Platform/PlatformLaunchValidatorInterface.php) can be provided.
+
+### LTI tool message launch validator interface
+
+**Default implementation**: [ToolLaunchValidator](../../src/Message/Launch/Validator/Tool/ToolLaunchValidator.php)
+
+To customise tool message launch validation, an implementation of the [ToolLaunchValidatorInterface](../../src/Message/Launch/Validator/Tool/ToolLaunchValidatorInterface.php) can be provided.
+
+### LTI service client interface
 
 **Default implementation**: [LtiServiceClient](../../src/Service/Client/LtiServiceClient.php) 
 
@@ -168,7 +180,19 @@ $client = new class implements LtiServiceClientInterface
 **Notes**:                                                                                                                                                                                                                                                                            
 - it is recommended to put in cache the service access tokens, to improve performances. Your implementation can then rely on an injected [PSR6 cache](https://www.php-fig.org/psr/psr-6/#cacheitempoolinterface) by example.
 
-### LTI Service server client repository interface
+### LTI tool service server access token generator interface
+
+**Default implementation**: [AccessTokenResponseGenerator](../../src/Security/OAuth2/Generator/AccessTokenResponseGenerator.php)
+
+To customise access token generation, an implementation of the [AccessTokenResponseGeneratorInterface](../../src/Security/OAuth2/Generator/AccessTokenResponseGeneratorInterface.php) can be provided.
+
+### LTI tool service server access token validator interface
+
+**Default implementation**: [RequestAccessTokenValidator](../../src/Security/OAuth2/Validator/RequestAccessTokenValidator.php)
+
+To customise access token validation, an implementation of the [RequestAccessTokenValidatorInterface](../../src/Security/OAuth2/Validator/RequestAccessTokenValidatorInterface.php) can be provided.
+
+### LTI service server client repository interface
 
 **Default implementation**: [ClientRepository](../../src/Security/OAuth2/Repository/ClientRepository.php)  
 
@@ -178,7 +202,7 @@ In order to retrieve and validate clients involved in authenticated service call
 - the default `ClientRepository` injects the `RegistrationRepositoryInterface` to be able to expose your platforms as oauth2 providers and tools as consumers.
 - in case of the consumer tool public key is not given in the registration, it will automatically fallback to a JWKS call.
 
-### LTI Service server access token repository interface
+### LTI service server access token repository interface
 
 **Default implementation**: [AccessTokenRepository](../../src/Security/OAuth2/Repository/AccessTokenRepository.php)  
 
@@ -186,7 +210,7 @@ In order to store service calls access tokens, an implementation of the [AccessT
 
 **Note**: the default `AccessTokenRepository` implementation rely on a [PSR6 cache](https://www.php-fig.org/psr/psr-6/#cacheitempoolinterface) to store generated access tokens.
 
-### LTI Service server scope repository interface
+### LTI service server scope repository interface
 
 **Default implementation**: [ScopeRepository](../../src/Security/OAuth2/Repository/ScopeRepository.php)  
 

--- a/doc/quickstart/interfaces.md
+++ b/doc/quickstart/interfaces.md
@@ -180,13 +180,13 @@ $client = new class implements LtiServiceClientInterface
 **Notes**:                                                                                                                                                                                                                                                                            
 - it is recommended to put in cache the service access tokens, to improve performances. Your implementation can then rely on an injected [PSR6 cache](https://www.php-fig.org/psr/psr-6/#cacheitempoolinterface) by example.
 
-### LTI tool service server access token generator interface
+### LTI service server access token generator interface
 
 **Default implementation**: [AccessTokenResponseGenerator](../../src/Security/OAuth2/Generator/AccessTokenResponseGenerator.php)
 
 To customise access token generation, an implementation of the [AccessTokenResponseGeneratorInterface](../../src/Security/OAuth2/Generator/AccessTokenResponseGeneratorInterface.php) can be provided.
 
-### LTI tool service server access token validator interface
+### LTI service server access token validator interface
 
 **Default implementation**: [RequestAccessTokenValidator](../../src/Security/OAuth2/Validator/RequestAccessTokenValidator.php)
 

--- a/doc/service/service-server.md
+++ b/doc/service/service-server.md
@@ -25,7 +25,7 @@ Your will also need to provide an encryption key (random string with enough entr
 
 ## Generation of access token response for a key chain
 
-This library provides a ready to use [AccessTokenGenerator](../../src/Security/OAuth2/Generator/AccessTokenResponseGenerator.php) to generate access tokens responses for a given key chain:
+This library provides a ready to use [AccessTokenResponseGenerator](../../src/Security/OAuth2/Generator/AccessTokenResponseGenerator.php) to generate access tokens responses for a given key chain:
 - it requires a key chain repository implementation [as explained here](../quickstart/interfaces.md) to automate signature logic against a key chain private key
 - it complies to the `client_credentials` grant type with `client_assertion` to follow [IMS security specifications](https://www.imsglobal.org/spec/security/v1p0/#using-json-web-tokens-with-oauth-2-0-client-credentials-grant)
 - it expects a [PSR7 ServerRequestInterface](https://www.php-fig.org/psr/psr-7/#321-psrhttpmessageserverrequestinterface), a [PSR7 ResponseInterface](https://www.php-fig.org/psr/psr-7/#33-psrhttpmessageresponseinterface) and a key chain identifier to be easily exposed behind any PSR7 compliant controller

--- a/src/Message/Launch/Validator/AbstractLaunchValidator.php
+++ b/src/Message/Launch/Validator/AbstractLaunchValidator.php
@@ -31,7 +31,7 @@ use OAT\Library\Lti1p3Core\Security\Jwt\Validator\Validator;
 use OAT\Library\Lti1p3Core\Security\Jwt\Validator\ValidatorInterface;
 use OAT\Library\Lti1p3Core\Security\Nonce\NonceRepositoryInterface;
 
-abstract class AbstractLaunchValidator
+abstract class AbstractLaunchValidator implements LaunchValidatorInterface
 {
     /** @var RegistrationRepositoryInterface */
     protected $registrationRepository;
@@ -64,8 +64,6 @@ abstract class AbstractLaunchValidator
         $this->validator = $validator ?? new Validator();
         $this->parser = $parser ?? new Parser();
     }
-
-    abstract public function getSupportedMessageTypes(): array;
 
     protected function addSuccess(string $message): self
     {

--- a/src/Message/Launch/Validator/LaunchValidatorInterface.php
+++ b/src/Message/Launch/Validator/LaunchValidatorInterface.php
@@ -15,7 +15,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2020 (original work) Open Assessment Technologies SA;
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA;
  */
 
 declare(strict_types=1);

--- a/src/Message/Launch/Validator/LaunchValidatorInterface.php
+++ b/src/Message/Launch/Validator/LaunchValidatorInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace OAT\Library\Lti1p3Core\Message\Launch\Validator;
+
+interface LaunchValidatorInterface
+{
+    public function getSupportedMessageTypes(): array;
+}

--- a/src/Message/Launch/Validator/Platform/PlatformLaunchValidator.php
+++ b/src/Message/Launch/Validator/Platform/PlatformLaunchValidator.php
@@ -15,17 +15,19 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2020 (original work) Open Assessment Technologies SA;
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA;
  */
 
 declare(strict_types=1);
 
-namespace OAT\Library\Lti1p3Core\Message\Launch\Validator;
+namespace OAT\Library\Lti1p3Core\Message\Launch\Validator\Platform;
 
 use Carbon\Carbon;
 use OAT\Library\Lti1p3Core\Exception\LtiException;
 use OAT\Library\Lti1p3Core\Exception\LtiExceptionInterface;
+use OAT\Library\Lti1p3Core\Message\Launch\Validator\AbstractLaunchValidator;
 use OAT\Library\Lti1p3Core\Message\Launch\Validator\Result\LaunchValidationResult;
+use OAT\Library\Lti1p3Core\Message\Launch\Validator\Result\LaunchValidationResultInterface;
 use OAT\Library\Lti1p3Core\Message\LtiMessage;
 use OAT\Library\Lti1p3Core\Message\LtiMessageInterface;
 use OAT\Library\Lti1p3Core\Message\Payload\LtiMessagePayload;
@@ -40,7 +42,7 @@ use Throwable;
 /**
  * @see https://www.imsglobal.org/spec/security/v1p0/#authentication-response-validation-0
  */
-class PlatformLaunchValidator extends AbstractLaunchValidator
+class PlatformLaunchValidator extends AbstractLaunchValidator implements PlatformLaunchValidatorInterface
 {
     public function getSupportedMessageTypes(): array
     {
@@ -50,7 +52,7 @@ class PlatformLaunchValidator extends AbstractLaunchValidator
         ];
     }
 
-    public function validateToolOriginatingLaunch(ServerRequestInterface $request): LaunchValidationResult
+    public function validateToolOriginatingLaunch(ServerRequestInterface $request): LaunchValidationResultInterface
     {
         $this->reset();
 

--- a/src/Message/Launch/Validator/Platform/PlatformLaunchValidatorInterface.php
+++ b/src/Message/Launch/Validator/Platform/PlatformLaunchValidatorInterface.php
@@ -20,25 +20,16 @@
 
 declare(strict_types=1);
 
-namespace OAT\Library\Lti1p3Core\Service\Server\Handler;
+namespace OAT\Library\Lti1p3Core\Message\Launch\Validator\Platform;
 
-use OAT\Library\Lti1p3Core\Security\OAuth2\Validator\Result\RequestAccessTokenValidationResultInterface;
-use Psr\Http\Message\ResponseInterface;
+use OAT\Library\Lti1p3Core\Message\Launch\Validator\LaunchValidatorInterface;
+use OAT\Library\Lti1p3Core\Message\Launch\Validator\Result\LaunchValidationResultInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
-interface LtiServiceServerRequestHandlerInterface
+/**
+ * @see https://www.imsglobal.org/spec/security/v1p0/#authentication-response-validation-0
+ */
+interface PlatformLaunchValidatorInterface extends LaunchValidatorInterface
 {
-    public function getServiceName(): string;
-
-    public function getAllowedContentType(): ?string;
-
-    public function getAllowedMethods(): array;
-
-    public function getAllowedScopes(): array;
-
-    public function handleValidatedServiceRequest(
-        RequestAccessTokenValidationResultInterface $validationResult,
-        ServerRequestInterface $request,
-        array $options = []
-    ): ResponseInterface;
+    public function validateToolOriginatingLaunch(ServerRequestInterface $request): LaunchValidationResultInterface;
 }

--- a/src/Message/Launch/Validator/Result/LaunchValidationResult.php
+++ b/src/Message/Launch/Validator/Result/LaunchValidationResult.php
@@ -15,7 +15,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2020 (original work) Open Assessment Technologies SA;
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA;
  */
 
 declare(strict_types=1);
@@ -27,7 +27,7 @@ use OAT\Library\Lti1p3Core\Message\Payload\MessagePayloadInterface;
 use OAT\Library\Lti1p3Core\Registration\RegistrationInterface;
 use OAT\Library\Lti1p3Core\Util\Result\Result;
 
-class LaunchValidationResult extends Result
+class LaunchValidationResult extends Result implements LaunchValidationResultInterface
 {
     /** @var RegistrationInterface|null */
     private $registration;

--- a/src/Message/Launch/Validator/Result/LaunchValidationResultInterface.php
+++ b/src/Message/Launch/Validator/Result/LaunchValidationResultInterface.php
@@ -20,25 +20,18 @@
 
 declare(strict_types=1);
 
-namespace OAT\Library\Lti1p3Core\Service\Server\Handler;
+namespace OAT\Library\Lti1p3Core\Message\Launch\Validator\Result;
 
-use OAT\Library\Lti1p3Core\Security\OAuth2\Validator\Result\RequestAccessTokenValidationResultInterface;
-use Psr\Http\Message\ResponseInterface;
-use Psr\Http\Message\ServerRequestInterface;
+use OAT\Library\Lti1p3Core\Message\Payload\LtiMessagePayloadInterface;
+use OAT\Library\Lti1p3Core\Message\Payload\MessagePayloadInterface;
+use OAT\Library\Lti1p3Core\Registration\RegistrationInterface;
+use OAT\Library\Lti1p3Core\Util\Result\ResultInterface;
 
-interface LtiServiceServerRequestHandlerInterface
+interface LaunchValidationResultInterface extends ResultInterface
 {
-    public function getServiceName(): string;
+    public function getRegistration(): ?RegistrationInterface;
 
-    public function getAllowedContentType(): ?string;
+    public function getPayload(): ?LtiMessagePayloadInterface;
 
-    public function getAllowedMethods(): array;
-
-    public function getAllowedScopes(): array;
-
-    public function handleValidatedServiceRequest(
-        RequestAccessTokenValidationResultInterface $validationResult,
-        ServerRequestInterface $request,
-        array $options = []
-    ): ResponseInterface;
+    public function getState(): ?MessagePayloadInterface;
 }

--- a/src/Message/Launch/Validator/Tool/ToolLaunchValidator.php
+++ b/src/Message/Launch/Validator/Tool/ToolLaunchValidator.php
@@ -15,17 +15,19 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2020 (original work) Open Assessment Technologies SA;
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA;
  */
 
 declare(strict_types=1);
 
-namespace OAT\Library\Lti1p3Core\Message\Launch\Validator;
+namespace OAT\Library\Lti1p3Core\Message\Launch\Validator\Tool;
 
 use Carbon\Carbon;
 use OAT\Library\Lti1p3Core\Exception\LtiException;
 use OAT\Library\Lti1p3Core\Exception\LtiExceptionInterface;
+use OAT\Library\Lti1p3Core\Message\Launch\Validator\AbstractLaunchValidator;
 use OAT\Library\Lti1p3Core\Message\Launch\Validator\Result\LaunchValidationResult;
+use OAT\Library\Lti1p3Core\Message\Launch\Validator\Result\LaunchValidationResultInterface;
 use OAT\Library\Lti1p3Core\Message\LtiMessage;
 use OAT\Library\Lti1p3Core\Message\LtiMessageInterface;
 use OAT\Library\Lti1p3Core\Message\Payload\LtiMessagePayload;
@@ -41,7 +43,7 @@ use Throwable;
 /**
  * @see https://www.imsglobal.org/spec/security/v1p0/#authentication-response-validation
  */
-class ToolLaunchValidator extends AbstractLaunchValidator
+class ToolLaunchValidator extends AbstractLaunchValidator implements ToolLaunchValidatorInterface
 {
     public function getSupportedMessageTypes(): array
     {
@@ -52,7 +54,7 @@ class ToolLaunchValidator extends AbstractLaunchValidator
         ];
     }
 
-    public function validatePlatformOriginatingLaunch(ServerRequestInterface $request): LaunchValidationResult
+    public function validatePlatformOriginatingLaunch(ServerRequestInterface $request): LaunchValidationResultInterface
     {
         $this->reset();
 

--- a/src/Message/Launch/Validator/Tool/ToolLaunchValidatorInterface.php
+++ b/src/Message/Launch/Validator/Tool/ToolLaunchValidatorInterface.php
@@ -20,25 +20,16 @@
 
 declare(strict_types=1);
 
-namespace OAT\Library\Lti1p3Core\Service\Server\Handler;
+namespace OAT\Library\Lti1p3Core\Message\Launch\Validator\Tool;
 
-use OAT\Library\Lti1p3Core\Security\OAuth2\Validator\Result\RequestAccessTokenValidationResultInterface;
-use Psr\Http\Message\ResponseInterface;
+use OAT\Library\Lti1p3Core\Message\Launch\Validator\LaunchValidatorInterface;
+use OAT\Library\Lti1p3Core\Message\Launch\Validator\Result\LaunchValidationResultInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
-interface LtiServiceServerRequestHandlerInterface
+/**
+ * @see https://www.imsglobal.org/spec/security/v1p0/#authentication-response-validation
+ */
+interface ToolLaunchValidatorInterface extends LaunchValidatorInterface
 {
-    public function getServiceName(): string;
-
-    public function getAllowedContentType(): ?string;
-
-    public function getAllowedMethods(): array;
-
-    public function getAllowedScopes(): array;
-
-    public function handleValidatedServiceRequest(
-        RequestAccessTokenValidationResultInterface $validationResult,
-        ServerRequestInterface $request,
-        array $options = []
-    ): ResponseInterface;
+    public function validatePlatformOriginatingLaunch(ServerRequestInterface $request): LaunchValidationResultInterface;
 }

--- a/src/Security/OAuth2/Generator/AccessTokenResponseGenerator.php
+++ b/src/Security/OAuth2/Generator/AccessTokenResponseGenerator.php
@@ -15,7 +15,7 @@
  *  along with this program; if not, write to the Free Software
  *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- *  Copyright (c) 2020 (original work) Open Assessment Technologies S.A.
+ *  Copyright (c) 2021 (original work) Open Assessment Technologies S.A.
  */
 
 declare(strict_types=1);

--- a/src/Security/OAuth2/Generator/AccessTokenResponseGeneratorInterface.php
+++ b/src/Security/OAuth2/Generator/AccessTokenResponseGeneratorInterface.php
@@ -15,7 +15,7 @@
  *  along with this program; if not, write to the Free Software
  *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- *  Copyright (c) 2020 (original work) Open Assessment Technologies S.A.
+ *  Copyright (c) 2021 (original work) Open Assessment Technologies S.A.
  */
 
 declare(strict_types=1);

--- a/src/Security/OAuth2/Generator/AccessTokenResponseGeneratorInterface.php
+++ b/src/Security/OAuth2/Generator/AccessTokenResponseGeneratorInterface.php
@@ -23,25 +23,11 @@ declare(strict_types=1);
 namespace OAT\Library\Lti1p3Core\Security\OAuth2\Generator;
 
 use League\OAuth2\Server\Exception\OAuthServerException;
-use OAT\Library\Lti1p3Core\Security\Key\KeyChainRepositoryInterface;
-use OAT\Library\Lti1p3Core\Security\OAuth2\Factory\AuthorizationServerFactory;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
-class AccessTokenResponseGenerator implements AccessTokenResponseGeneratorInterface
+interface AccessTokenResponseGeneratorInterface
 {
-    /** @var KeyChainRepositoryInterface */
-    private $repository;
-
-    /** @var AuthorizationServerFactory */
-    private $factory;
-
-    public function __construct(KeyChainRepositoryInterface $repository, AuthorizationServerFactory $factory)
-    {
-        $this->repository = $repository;
-        $this->factory = $factory;
-    }
-
     /**
      * @throws OAuthServerException
      */
@@ -49,15 +35,5 @@ class AccessTokenResponseGenerator implements AccessTokenResponseGeneratorInterf
         ServerRequestInterface $request,
         ResponseInterface $response,
         string $keyChainIdentifier
-    ): ResponseInterface {
-        $keyChain = $this->repository->find($keyChainIdentifier);
-
-        if (null === $keyChain) {
-            throw new OAuthServerException('Invalid key chain identifier', 11, 'key_chain_not_found', 404);
-        }
-
-        return $this->factory
-            ->create($keyChain)
-            ->respondToAccessTokenRequest($request, $response);
-    }
+    ): ResponseInterface;
 }

--- a/src/Security/OAuth2/Validator/RequestAccessTokenValidator.php
+++ b/src/Security/OAuth2/Validator/RequestAccessTokenValidator.php
@@ -15,7 +15,7 @@
  *  along with this program; if not, write to the Free Software
  *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- *  Copyright (c) 2020 (original work) Open Assessment Technologies S.A.
+ *  Copyright (c) 2021 (original work) Open Assessment Technologies S.A.
  */
 
 declare(strict_types=1);

--- a/src/Security/OAuth2/Validator/RequestAccessTokenValidator.php
+++ b/src/Security/OAuth2/Validator/RequestAccessTokenValidator.php
@@ -29,12 +29,13 @@ use OAT\Library\Lti1p3Core\Security\Jwt\Parser\ParserInterface;
 use OAT\Library\Lti1p3Core\Security\Jwt\Validator\Validator;
 use OAT\Library\Lti1p3Core\Security\Jwt\Validator\ValidatorInterface;
 use OAT\Library\Lti1p3Core\Security\OAuth2\Validator\Result\RequestAccessTokenValidationResult;
+use OAT\Library\Lti1p3Core\Security\OAuth2\Validator\Result\RequestAccessTokenValidationResultInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Throwable;
 
-class RequestAccessTokenValidator
+class RequestAccessTokenValidator implements RequestAccessTokenValidatorInterface
 {
     /** @var RegistrationRepositoryInterface */
     private $repository;
@@ -63,8 +64,10 @@ class RequestAccessTokenValidator
         $this->parser = $parser ?? new Parser();
     }
 
-    public function validate(ServerRequestInterface $request, array $allowedScopes = []): RequestAccessTokenValidationResult
-    {
+    public function validate(
+        ServerRequestInterface $request,
+        array $allowedScopes = []
+    ): RequestAccessTokenValidationResultInterface {
         $this->reset();
 
         try {

--- a/src/Security/OAuth2/Validator/RequestAccessTokenValidatorInterface.php
+++ b/src/Security/OAuth2/Validator/RequestAccessTokenValidatorInterface.php
@@ -15,7 +15,7 @@
  *  along with this program; if not, write to the Free Software
  *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- *  Copyright (c) 2020 (original work) Open Assessment Technologies S.A.
+ *  Copyright (c) 2021 (original work) Open Assessment Technologies S.A.
  */
 
 declare(strict_types=1);

--- a/src/Security/OAuth2/Validator/RequestAccessTokenValidatorInterface.php
+++ b/src/Security/OAuth2/Validator/RequestAccessTokenValidatorInterface.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ *  This program is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU General Public License
+ *  as published by the Free Software Foundation; under version 2
+ *  of the License (non-upgradable).
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ *  Copyright (c) 2020 (original work) Open Assessment Technologies S.A.
+ */
+
+declare(strict_types=1);
+
+namespace OAT\Library\Lti1p3Core\Security\OAuth2\Validator;
+
+use OAT\Library\Lti1p3Core\Security\OAuth2\Validator\Result\RequestAccessTokenValidationResultInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+interface RequestAccessTokenValidatorInterface
+{
+    public function validate(
+        ServerRequestInterface $request,
+        array $allowedScopes = []
+    ): RequestAccessTokenValidationResultInterface;
+}

--- a/src/Security/OAuth2/Validator/Result/RequestAccessTokenValidationResult.php
+++ b/src/Security/OAuth2/Validator/Result/RequestAccessTokenValidationResult.php
@@ -15,7 +15,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2020 (original work) Open Assessment Technologies SA;
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA;
  */
 
 declare(strict_types=1);

--- a/src/Security/OAuth2/Validator/Result/RequestAccessTokenValidationResultInterface.php
+++ b/src/Security/OAuth2/Validator/Result/RequestAccessTokenValidationResultInterface.php
@@ -15,7 +15,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2020 (original work) Open Assessment Technologies SA;
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA;
  */
 
 declare(strict_types=1);

--- a/src/Security/OAuth2/Validator/Result/RequestAccessTokenValidationResultInterface.php
+++ b/src/Security/OAuth2/Validator/Result/RequestAccessTokenValidationResultInterface.php
@@ -24,40 +24,13 @@ namespace OAT\Library\Lti1p3Core\Security\OAuth2\Validator\Result;
 
 use OAT\Library\Lti1p3Core\Registration\RegistrationInterface;
 use OAT\Library\Lti1p3Core\Security\Jwt\TokenInterface;
-use OAT\Library\Lti1p3Core\Util\Result\Result;
+use OAT\Library\Lti1p3Core\Util\Result\ResultInterface;
 
-class RequestAccessTokenValidationResult extends Result implements RequestAccessTokenValidationResultInterface
+interface RequestAccessTokenValidationResultInterface extends ResultInterface
 {
-    /** @var RegistrationInterface|null */
-    private $registration;
+    public function getRegistration(): ?RegistrationInterface;
 
-    /** @var TokenInterface|null */
-    private $token;
+    public function getToken(): ?TokenInterface;
 
-    public function __construct(
-        ?RegistrationInterface $registration = null,
-        ?TokenInterface $token = null,
-        array $successes = [],
-        ?string $error = null
-    ) {
-        $this->registration = $registration;
-        $this->token = $token;
-
-        parent::__construct($successes, $error);
-    }
-
-    public function getRegistration(): ?RegistrationInterface
-    {
-        return $this->registration;
-    }
-
-    public function getToken(): ?TokenInterface
-    {
-        return $this->token;
-    }
-
-    public function getScopes(): array
-    {
-        return $this->token->getClaims()->get('scopes', []);
-    }
+    public function getScopes(): array;
 }

--- a/src/Service/Server/LtiServiceServer.php
+++ b/src/Service/Server/LtiServiceServer.php
@@ -24,7 +24,7 @@ namespace OAT\Library\Lti1p3Core\Service\Server;
 
 use Http\Message\ResponseFactory;
 use Nyholm\Psr7\Factory\HttplugFactory;
-use OAT\Library\Lti1p3Core\Security\OAuth2\Validator\RequestAccessTokenValidator;
+use OAT\Library\Lti1p3Core\Security\OAuth2\Validator\RequestAccessTokenValidatorInterface;
 use OAT\Library\Lti1p3Core\Service\Server\Handler\LtiServiceServerRequestHandlerInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -35,7 +35,7 @@ use Throwable;
 
 class LtiServiceServer implements RequestHandlerInterface
 {
-    /** @var RequestAccessTokenValidator */
+    /** @var RequestAccessTokenValidatorInterface */
     private $validator;
 
     /** @var LtiServiceServerRequestHandlerInterface */
@@ -48,7 +48,7 @@ class LtiServiceServer implements RequestHandlerInterface
     private $logger;
 
     public function __construct(
-        RequestAccessTokenValidator $validator,
+        RequestAccessTokenValidatorInterface $validator,
         LtiServiceServerRequestHandlerInterface $handler,
         ?ResponseFactory $factory = null,
         ?LoggerInterface $logger = null
@@ -88,7 +88,7 @@ class LtiServiceServer implements RequestHandlerInterface
         }
 
         try {
-            $response = $this->handler->handleServiceRequest($validationResult->getRegistration(), $request);
+            $response = $this->handler->handleValidatedServiceRequest($validationResult, $request);
 
             $this->logger->info(sprintf('%s service success', $this->handler->getServiceName()));
 

--- a/tests/Integration/Flow/Message/PlatformOriginatingMessageFlowTest.php
+++ b/tests/Integration/Flow/Message/PlatformOriginatingMessageFlowTest.php
@@ -23,7 +23,7 @@ declare(strict_types=1);
 namespace OAT\Library\Lti1p3Core\Tests\Integration\Flow\Message;
 
 use OAT\Library\Lti1p3Core\Message\Launch\Builder\LtiResourceLinkLaunchRequestBuilder;
-use OAT\Library\Lti1p3Core\Message\Launch\Validator\ToolLaunchValidator;
+use OAT\Library\Lti1p3Core\Message\Launch\Validator\Tool\ToolLaunchValidator;
 use OAT\Library\Lti1p3Core\Message\LtiMessageInterface;
 use OAT\Library\Lti1p3Core\Message\Payload\Claim\ContextClaim;
 use OAT\Library\Lti1p3Core\Registration\RegistrationInterface;

--- a/tests/Integration/Flow/Message/ToolOriginatingMessageFlowTest.php
+++ b/tests/Integration/Flow/Message/ToolOriginatingMessageFlowTest.php
@@ -23,7 +23,7 @@ declare(strict_types=1);
 namespace OAT\Library\Lti1p3Core\Tests\Integration\Flow\Message;
 
 use OAT\Library\Lti1p3Core\Message\Launch\Builder\ToolOriginatingLaunchBuilder;
-use OAT\Library\Lti1p3Core\Message\Launch\Validator\PlatformLaunchValidator;
+use OAT\Library\Lti1p3Core\Message\Launch\Validator\Platform\PlatformLaunchValidator;
 use OAT\Library\Lti1p3Core\Message\LtiMessageInterface;
 use OAT\Library\Lti1p3Core\Message\Payload\LtiMessagePayloadInterface;
 use OAT\Library\Lti1p3Core\Registration\RegistrationInterface;

--- a/tests/Integration/Message/Launch/Validator/Platform/PlatformLaunchValidatorTest.php
+++ b/tests/Integration/Message/Launch/Validator/Platform/PlatformLaunchValidatorTest.php
@@ -20,12 +20,13 @@
 
 declare(strict_types=1);
 
-namespace OAT\Library\Lti1p3Core\Tests\Integration\Message\Launch\Validator;
+namespace OAT\Library\Lti1p3Core\Tests\Integration\Message\Launch\Validator\Platform;
 
 use Carbon\Carbon;
 use OAT\Library\Lti1p3Core\Message\Launch\Builder\ToolOriginatingLaunchBuilder;
-use OAT\Library\Lti1p3Core\Message\Launch\Validator\PlatformLaunchValidator;
+use OAT\Library\Lti1p3Core\Message\Launch\Validator\Platform\PlatformLaunchValidator;
 use OAT\Library\Lti1p3Core\Message\Launch\Validator\Result\LaunchValidationResult;
+use OAT\Library\Lti1p3Core\Message\Launch\Validator\Result\LaunchValidationResultInterface;
 use OAT\Library\Lti1p3Core\Message\LtiMessageInterface;
 use OAT\Library\Lti1p3Core\Message\Payload\LtiMessagePayloadInterface;
 use OAT\Library\Lti1p3Core\Message\Payload\MessagePayloadInterface;
@@ -98,7 +99,7 @@ class PlatformLaunchValidatorTest extends TestCase
 
         $result = $this->subject->validateToolOriginatingLaunch($this->createServerRequest('GET', $message->toUrl()));
 
-        $this->assertInstanceOf(LaunchValidationResult::class, $result);
+        $this->assertInstanceOf(LaunchValidationResultInterface::class, $result);
         $this->assertFalse($result->hasError());
 
         $this->verifyJwt($result->getPayload()->getToken(), $this->registration->getToolKeyChain()->getPublicKey());
@@ -129,7 +130,7 @@ class PlatformLaunchValidatorTest extends TestCase
 
         $result = $this->subject->validateToolOriginatingLaunch($this->createServerRequest('GET', $message->toUrl()));
 
-        $this->assertInstanceOf(LaunchValidationResult::class, $result);
+        $this->assertInstanceOf(LaunchValidationResultInterface::class, $result);
         $this->assertTrue($result->hasError());
         $this->assertEquals('JWT validation failure', $result->getError());
     }
@@ -191,7 +192,7 @@ class PlatformLaunchValidatorTest extends TestCase
 
         $result = $this->subject->validateToolOriginatingLaunch($request);
 
-        $this->assertInstanceOf(LaunchValidationResult::class, $result);
+        $this->assertInstanceOf(LaunchValidationResultInterface::class, $result);
         $this->assertTrue($result->hasError());
         $this->assertEquals($expectedErrorMessage, $result->getError());
     }
@@ -252,7 +253,7 @@ class PlatformLaunchValidatorTest extends TestCase
 
         $result = $subject->validateToolOriginatingLaunch($this->createServerRequest('GET', $message->toUrl()));
 
-        $this->assertInstanceOf(LaunchValidationResult::class, $result);
+        $this->assertInstanceOf(LaunchValidationResultInterface::class, $result);
         $this->assertTrue($result->hasError());
         $this->assertEquals(
             'JWT session_data proctoring claim validation failure: platform key chain is not configured',

--- a/tests/Integration/Message/Launch/Validator/Tool/ToolLaunchValidatorTest.php
+++ b/tests/Integration/Message/Launch/Validator/Tool/ToolLaunchValidatorTest.php
@@ -20,12 +20,12 @@
 
 declare(strict_types=1);
 
-namespace OAT\Library\Lti1p3Core\Tests\Integration\Message\Launch\Validator;
+namespace OAT\Library\Lti1p3Core\Tests\Integration\Message\Launch\Validator\Tool;
 
 use Carbon\Carbon;
 use OAT\Library\Lti1p3Core\Message\Launch\Builder\PlatformOriginatingLaunchBuilder;
-use OAT\Library\Lti1p3Core\Message\Launch\Validator\Result\LaunchValidationResult;
-use OAT\Library\Lti1p3Core\Message\Launch\Validator\ToolLaunchValidator;
+use OAT\Library\Lti1p3Core\Message\Launch\Validator\Result\LaunchValidationResultInterface;
+use OAT\Library\Lti1p3Core\Message\Launch\Validator\Tool\ToolLaunchValidator;
 use OAT\Library\Lti1p3Core\Message\LtiMessageInterface;
 use OAT\Library\Lti1p3Core\Message\Payload\Claim\DeepLinkingSettingsClaim;
 use OAT\Library\Lti1p3Core\Message\Payload\Claim\ResourceLinkClaim;
@@ -108,7 +108,7 @@ class ToolLaunchValidatorTest extends TestCase
 
         $result = $this->subject->validatePlatformOriginatingLaunch($this->buildOidcFlowRequest($message));
 
-        $this->assertInstanceOf(LaunchValidationResult::class, $result);
+        $this->assertInstanceOf(LaunchValidationResultInterface::class, $result);
         $this->assertFalse($result->hasError());
 
         $this->verifyJwt($result->getPayload()->getToken(), $this->registration->getPlatformKeyChain()->getPublicKey());
@@ -149,7 +149,7 @@ class ToolLaunchValidatorTest extends TestCase
 
         $result = $this->subject->validatePlatformOriginatingLaunch($this->buildOidcFlowRequest($message));
 
-        $this->assertInstanceOf(LaunchValidationResult::class, $result);
+        $this->assertInstanceOf(LaunchValidationResultInterface::class, $result);
         $this->assertFalse($result->hasError());
 
         $this->verifyJwt($result->getPayload()->getToken(), $this->registration->getPlatformKeyChain()->getPublicKey());
@@ -197,7 +197,7 @@ class ToolLaunchValidatorTest extends TestCase
 
         $result = $this->subject->validatePlatformOriginatingLaunch($this->buildOidcFlowRequest($message));
 
-        $this->assertInstanceOf(LaunchValidationResult::class, $result);
+        $this->assertInstanceOf(LaunchValidationResultInterface::class, $result);
         $this->assertFalse($result->hasError());
 
         $this->verifyJwt($result->getPayload()->getToken(), $this->registration->getPlatformKeyChain()->getPublicKey());
@@ -254,7 +254,7 @@ class ToolLaunchValidatorTest extends TestCase
 
         $result =$subject->validatePlatformOriginatingLaunch($this->buildOidcFlowRequest($message));
 
-        $this->assertInstanceOf(LaunchValidationResult::class, $result);
+        $this->assertInstanceOf(LaunchValidationResultInterface::class, $result);
         $this->assertFalse($result->hasError());
     }
 
@@ -281,7 +281,7 @@ class ToolLaunchValidatorTest extends TestCase
 
         $result =$subject->validatePlatformOriginatingLaunch($this->buildOidcFlowRequest($message));
 
-        $this->assertInstanceOf(LaunchValidationResult::class, $result);
+        $this->assertInstanceOf(LaunchValidationResultInterface::class, $result);
         $this->assertTrue($result->hasError());
         $this->assertEquals('State validation failure: tool key chain not configured', $result->getError());
     }
@@ -299,7 +299,7 @@ class ToolLaunchValidatorTest extends TestCase
         $result = $this->subject->validatePlatformOriginatingLaunch($this->buildOidcFlowRequest($message));
         Carbon::setTestNow();
 
-        $this->assertInstanceOf(LaunchValidationResult::class, $result);
+        $this->assertInstanceOf(LaunchValidationResultInterface::class, $result);
         $this->assertTrue($result->hasError());
         $this->assertEquals('ID token validation failure', $result->getError());
     }
@@ -337,7 +337,7 @@ class ToolLaunchValidatorTest extends TestCase
 
         $result = $this->subject->validatePlatformOriginatingLaunch($request);
 
-        $this->assertInstanceOf(LaunchValidationResult::class, $result);
+        $this->assertInstanceOf(LaunchValidationResultInterface::class, $result);
         $this->assertTrue($result->hasError());
         $this->assertEquals('State validation failure', $result->getError());
     }
@@ -365,7 +365,7 @@ class ToolLaunchValidatorTest extends TestCase
 
         $result = $this->subject->validatePlatformOriginatingLaunch($request);
 
-        $this->assertInstanceOf(LaunchValidationResult::class, $result);
+        $this->assertInstanceOf(LaunchValidationResultInterface::class, $result);
         $this->assertTrue($result->hasError());
         $this->assertEquals($expectedErrorMessage, $result->getError());
     }

--- a/tests/Unit/Message/Launch/Validator/Result/LaunchValidationResultTest.php
+++ b/tests/Unit/Message/Launch/Validator/Result/LaunchValidationResultTest.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 namespace OAT\Library\Lti1p3Core\Tests\Unit\Message\Launch\Validator\Result;
 
 use OAT\Library\Lti1p3Core\Message\Launch\Validator\Result\LaunchValidationResult;
+use OAT\Library\Lti1p3Core\Message\Launch\Validator\Result\LaunchValidationResultInterface;
 use OAT\Library\Lti1p3Core\Message\Payload\LtiMessagePayloadInterface;
 use OAT\Library\Lti1p3Core\Message\Payload\MessagePayloadInterface;
 use OAT\Library\Lti1p3Core\Registration\RegistrationInterface;
@@ -30,6 +31,13 @@ use PHPUnit\Framework\TestCase;
 
 class LaunchValidationResultTest extends TestCase
 {
+    public function testImplementation(): void
+    {
+        $subject = new LaunchValidationResult($this->createMock(RegistrationInterface::class));
+
+        $this->assertInstanceOf(LaunchValidationResultInterface::class, $subject);
+    }
+
     public function testGetRegistration(): void
     {
         $registrationMock = $this->createMock(RegistrationInterface::class);

--- a/tests/Unit/Service/Server/LtiServiceServerTest.php
+++ b/tests/Unit/Service/Server/LtiServiceServerTest.php
@@ -24,8 +24,8 @@ namespace OAT\Library\Lti1p3Core\Tests\Unit\Service\Server;
 
 use Carbon\Carbon;
 use Exception;
-use OAT\Library\Lti1p3Core\Registration\RegistrationInterface;
 use OAT\Library\Lti1p3Core\Security\OAuth2\Validator\RequestAccessTokenValidator;
+use OAT\Library\Lti1p3Core\Security\OAuth2\Validator\Result\RequestAccessTokenValidationResultInterface;
 use OAT\Library\Lti1p3Core\Service\Server\Handler\LtiServiceServerRequestHandlerInterface;
 use OAT\Library\Lti1p3Core\Service\Server\LtiServiceServer;
 use OAT\Library\Lti1p3Core\Tests\Resource\Logger\TestLogger;
@@ -255,11 +255,12 @@ class LtiServiceServerTest extends TestCase
                 return $this->scopes;
             }
 
-            public function handleServiceRequest(
-                RegistrationInterface $registration,
-                ServerRequestInterface $request
+            public function handleValidatedServiceRequest(
+                RequestAccessTokenValidationResultInterface $validationResult,
+                ServerRequestInterface $request,
+                array $options = []
             ): ResponseInterface {
-                return call_user_func($this->func, $registration, $request);
+                return call_user_func($this->func, $validationResult, $request);
             }
         };
     }


### PR DESCRIPTION
* Added [migration guide](https://github.com/oat-sa/lib-lti1p3-core/wiki/Migration-from-5.x-to-6.x) to document breaking changes and migration steps
* Added LaunchValidatorInterface, PlatformLaunchValidatorInterface and ToolLaunchValidatorInterface
* Added AccessTokenResponseGeneratorInterface
* Added RequestAccessTokenValidatorInterface and RequestAccessTokenValidationResultInterface
* Moved PlatformLaunchValidator in Platform sub namespace  
* Moved ToolLaunchValidator in Tool sub namespace  
* Updated LtiServiceServerRequestHandlerInterface signature
* Updated documentation

target release: `6.0.0`