### PR TITLE
Fix: allow guzzle ^6.5 for compatibility with TAO CGEN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ CHANGELOG
 6.0.1
 -----
 
-* Updated Guzzle dependency to ^6.5 || ^7.2 to make LTI core lib compatible with TAO CGEN which requires Guzzle:6
+* Updated Guzzle dependency to ^6.5 || ^7.2
 
 6.0.0
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ CHANGELOG
 6.0.1
 -----
 
-* Guzzle ^6.5 allowed to make LTI core lib compatible with TAO CGEN
+* Updated Guzzle dependency to ^6.5 || ^7.2 to make LTI core lib compatible with TAO CGEN which requires Guzzle:6
 
 6.0.0
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.0.1
+-----
+
+* Guzzle ^6.5 allowed to make LTI core lib compatible with TAO CGEN
+
 6.0.0
 -----
 

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "ext-openssl": "*",
         "ext-json": "*",
         "codercat/jwk-to-pem": "^1.0",
-        "guzzlehttp/guzzle": "^7.2",
+        "guzzlehttp/guzzle": "^6.5 || ^7.2",
         "lcobucci/jwt": "^3.4 || ^4.0",
         "league/oauth2-server": "^8.2",
         "nesbot/carbon": "^2.43",


### PR DESCRIPTION
Ticket: https://oat-sa.atlassian.net/browse/TR-948

To integrate lib-lti1p3-core:6 (here's the PR https://github.com/oat-sa/extension-tao-lti/pull/293) with TAO CGEN we need `Guzzle: ^6.5` to be an option, as many CGEN extensions rely on Guzzle:6.