### PR TITLE
Extended psr/log dependency versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.5.0
+-----
+
+* Extended psr/log dependency versions
+
 6.4.0
 -----
 

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "psr/cache": "^1.0 || ^2.0 || ^3.0",
         "psr/http-message": "^1.0",
         "psr/http-server-handler": "^1.0",
-        "psr/log": "^1.1",
+        "psr/log": "^1.0 || ^2.0 || ^3.0",
         "ramsey/uuid": "^3.9 || ^4"
     },
     "require-dev": {


### PR DESCRIPTION
feat: extended psr/log dependency versions

target release: `6.5.0`