### PR TITLE
Add support for LTI System Role TestUser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.7.0
+-----
+
+* Add LtiSystemRole supporting [TestUser role](http://www.imsglobal.org/spec/lti/v1p3/#lti-vocabulary-for-system-roles)
+
 6.6.0
 -----
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ CHANGELOG
 6.7.0
 -----
 
-* Add LtiSystemRole supporting [TestUser role](http://www.imsglobal.org/spec/lti/v1p3/#lti-vocabulary-for-system-roles)
+* Add LtiSystemRole supporting [TestUser role](https://www.imsglobal.org/spec/lti/v1p3/#lti-vocabulary-for-system-roles)
 
 6.6.0
 -----

--- a/src/Role/Factory/RoleFactory.php
+++ b/src/Role/Factory/RoleFactory.php
@@ -26,6 +26,7 @@ use OAT\Library\Lti1p3Core\Exception\LtiExceptionInterface;
 use OAT\Library\Lti1p3Core\Role\RoleInterface;
 use OAT\Library\Lti1p3Core\Role\Type\ContextRole;
 use OAT\Library\Lti1p3Core\Role\Type\InstitutionRole;
+use OAT\Library\Lti1p3Core\Role\Type\LtiSystemRole;
 use OAT\Library\Lti1p3Core\Role\Type\SystemRole;
 
 class RoleFactory
@@ -41,6 +42,10 @@ class RoleFactory
 
         if (strpos($name, InstitutionRole::getNameSpace()) === 0) {
             return new InstitutionRole($name);
+        }
+
+        if (strpos($name, LtiSystemRole::getNameSpace()) === 0) {
+            return new LtiSystemRole($name);
         }
 
         return new ContextRole($name);

--- a/src/Role/RoleInterface.php
+++ b/src/Role/RoleInterface.php
@@ -30,10 +30,12 @@ interface RoleInterface
     public const TYPE_SYSTEM = 'system';
     public const TYPE_INSTITUTION = 'institution';
     public const TYPE_CONTEXT = 'context';
+    public const TYPE_LTI_SYSTEM = 'lti-system';
 
     public const NAMESPACE_SYSTEM = 'http://purl.imsglobal.org/vocab/lis/v2/system/person';
     public const NAMESPACE_INSTITUTION = 'http://purl.imsglobal.org/vocab/lis/v2/institution/person';
     public const NAMESPACE_CONTEXT = 'http://purl.imsglobal.org/vocab/lis/v2/membership';
+    public const NAMESPACE_LTI_SYSTEM = 'http://purl.imsglobal.org/vocab/lti/system/person';
 
     public static function getType(): string;
 

--- a/src/Role/Type/LtiSystemRole.php
+++ b/src/Role/Type/LtiSystemRole.php
@@ -25,7 +25,7 @@ namespace OAT\Library\Lti1p3Core\Role\Type;
 use OAT\Library\Lti1p3Core\Role\AbstractRole;
 
 /**
- * @see http://www.imsglobal.org/spec/lti/v1p3/#lti-vocabulary-for-system-roles
+ * @see https://www.imsglobal.org/spec/lti/v1p3/#lti-vocabulary-for-system-roles
  */
 class LtiSystemRole extends AbstractRole
 {

--- a/src/Role/Type/LtiSystemRole.php
+++ b/src/Role/Type/LtiSystemRole.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace OAT\Library\Lti1p3Core\Role\Type;
+
+use OAT\Library\Lti1p3Core\Role\AbstractRole;
+
+/**
+ * @see http://www.imsglobal.org/spec/lti/v1p3/#lti-vocabulary-for-system-roles
+ */
+class LtiSystemRole extends AbstractRole
+{
+    public static function getType(): string
+    {
+        return static::TYPE_LTI_SYSTEM;
+    }
+
+    public static function getNameSpace(): string
+    {
+        return static::NAMESPACE_LTI_SYSTEM;
+    }
+
+    protected function getMap(): array
+    {
+        return  [
+            'TestUser' => true,
+        ];
+    }
+}

--- a/tests/Unit/Role/Factory/RoleFactoryTest.php
+++ b/tests/Unit/Role/Factory/RoleFactoryTest.php
@@ -26,6 +26,7 @@ use OAT\Library\Lti1p3Core\Exception\LtiExceptionInterface;
 use OAT\Library\Lti1p3Core\Role\Factory\RoleFactory;
 use OAT\Library\Lti1p3Core\Role\Type\ContextRole;
 use OAT\Library\Lti1p3Core\Role\Type\InstitutionRole;
+use OAT\Library\Lti1p3Core\Role\Type\LtiSystemRole;
 use OAT\Library\Lti1p3Core\Role\Type\SystemRole;
 use PHPUnit\Framework\TestCase;
 
@@ -79,6 +80,16 @@ class RoleFactoryTest extends TestCase
         $this->assertEquals('http://purl.imsglobal.org/vocab/lis/v2/membership/Administrator#Administrator', $result->getName());
         $this->assertEquals('Administrator', $result->getSubName());
         $this->assertFalse($result->isCore());
+    }
+
+    public function testCreateLtiSystemRole(): void
+    {
+        $result = RoleFactory::create('http://purl.imsglobal.org/vocab/lti/system/person#TestUser');
+
+        $this->assertInstanceOf(LtiSystemRole::class, $result);
+        $this->assertEquals('http://purl.imsglobal.org/vocab/lti/system/person#TestUser', $result->getName());
+        $this->assertNull($result->getSubName());
+        $this->assertTrue($result->isCore());
     }
 
     public function testCreateFailure(): void

--- a/tests/Unit/Role/Type/LtiSystemRoleTest.php
+++ b/tests/Unit/Role/Type/LtiSystemRoleTest.php
@@ -1,0 +1,78 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace OAT\Library\Lti1p3Core\Tests\Unit\Role\Type;
+
+use OAT\Library\Lti1p3Core\Exception\LtiExceptionInterface;
+use OAT\Library\Lti1p3Core\Role\RoleInterface;
+use OAT\Library\Lti1p3Core\Role\Type\LtiSystemRole;
+use PHPUnit\Framework\TestCase;
+
+class LtiSystemRoleTest extends TestCase
+{
+    /**
+     * @dataProvider provideValidRolesMap
+     */
+    public function testValidRoles(string $roleName, bool $isCore): void
+    {
+        $subject = new LtiSystemRole($roleName);
+
+        $this->assertEquals(RoleInterface::TYPE_LTI_SYSTEM, $subject::getType());
+        $this->assertEquals(RoleInterface::NAMESPACE_LTI_SYSTEM, $subject::getNameSpace());
+        $this->assertEquals($roleName, $subject->getName());
+        $this->assertNull($subject->getSubName());
+        $this->assertEquals($isCore, $subject->isCore());
+    }
+
+    /**
+     * @dataProvider provideInvalidRoles
+     */
+    public function testInvalidRole(string $roleName): void
+    {
+        $this->expectException(LtiExceptionInterface::class);
+        $this->expectExceptionMessage(sprintf('Role %s is invalid for type lti-system', $roleName));
+
+        new LtiSystemRole($roleName);
+    }
+
+    public function provideValidRolesMap(): array
+    {
+        return [
+            [
+                'roleName' => 'http://purl.imsglobal.org/vocab/lti/system/person#TestUser',
+                'isCore' => true
+            ],
+        ];
+    }
+
+    public function provideInvalidRoles(): array
+    {
+        return [
+            [
+                'roleName' => 'http://purl.imsglobal.org/vocab/lti/system/person#Invalid',
+            ],
+            [
+                'roleName' => 'Invalid',
+            ],
+        ];
+    }
+}

--- a/tests/Unit/Role/Type/LtiSystemRoleTest.php
+++ b/tests/Unit/Role/Type/LtiSystemRoleTest.php
@@ -59,7 +59,7 @@ class LtiSystemRoleTest extends TestCase
         return [
             [
                 'roleName' => 'http://purl.imsglobal.org/vocab/lti/system/person#TestUser',
-                'isCore' => true
+                'isCore' => true,
             ],
         ];
     }


### PR DESCRIPTION
There's a special role defined for LTI 1.3
http://purl.imsglobal.org/vocab/lti/system/person#TestUser
Defined here: http://www.imsglobal.org/spec/lti/v1p3/#lti-vocabulary-for-system-roles

Adding LtiSystemRole so this special role can be properly validated.  An exception is thrown when getting validated roles from a payload.  Ran into this when attempting to access LTI via Canvas "student view"
