### PR TITLE
feat: added aud claim validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+Unreleased
+-----
+
+* Added AUD claim validation in `LtiServiceClient`
+
 6.7.1
 -----
 

--- a/src/Service/Client/LtiServiceClient.php
+++ b/src/Service/Client/LtiServiceClient.php
@@ -25,6 +25,7 @@ namespace OAT\Library\Lti1p3Core\Service\Client;
 use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\ClientException;
+use InvalidArgumentException;
 use OAT\Library\Lti1p3Core\Exception\LtiException;
 use OAT\Library\Lti1p3Core\Exception\LtiExceptionInterface;
 use OAT\Library\Lti1p3Core\Message\Payload\MessagePayloadInterface;
@@ -195,6 +196,14 @@ class LtiServiceClient implements LtiServiceClientInterface
 
             if (null === $toolKeyChain) {
                 throw new LtiException('Tool key chain is not configured');
+            }
+
+            if ($registration->getPlatform()->getAudience() === '') {
+                throw new InvalidArgumentException('Platform audience cannot be null');
+            }
+
+            if ($registration->getPlatform()->getOAuth2AccessTokenUrl() === null) {
+                throw new InvalidArgumentException('Platform OAuth2 access token url cannot be null');
             }
 
             $token = $this->builder->build(

--- a/tests/Traits/DomainTestingTrait.php
+++ b/tests/Traits/DomainTestingTrait.php
@@ -197,6 +197,60 @@ trait DomainTestingTrait
         );
     }
 
+    private function createTestRegistrationWithoutPlatformAudience(
+        string $identifier = 'registrationIdentifier',
+        string $clientId = 'registrationClientId',
+        string $platformJwksUrl = 'http://platform.com/jwks',
+        string $toolJwksUrl = 'http://tool.com/jwks'
+    ): Registration {
+        $tool = $this->createTestTool();
+
+        return new Registration(
+            $identifier,
+            $clientId,
+            new Platform(
+                'platformIdentifier',
+                'platformName',
+                '',
+                'http://platform.com/oidc-auth',
+                'http://platform.com/access-token'
+            ),
+            $this->createTestTool(),
+            ['deploymentIdentifier'],
+            $this->createTestKeyChain('platformKeyChain'),
+            $this->createTestKeyChain('toolKeyChain'),
+            $platformJwksUrl,
+            $toolJwksUrl
+        );
+    }
+
+    private function createTestRegistrationWithoutPlatformOAuth2AccessTokenUrl(
+        string $identifier = 'registrationIdentifier',
+        string $clientId = 'registrationClientId',
+        string $platformJwksUrl = 'http://platform.com/jwks',
+        string $toolJwksUrl = 'http://tool.com/jwks'
+    ): Registration {
+        $tool = $this->createTestTool();
+
+        return new Registration(
+            $identifier,
+            $clientId,
+            new Platform(
+                'platformIdentifier',
+                'platformName',
+                'platformAudience',
+                'http://platform.com/oidc-auth',
+                null
+            ),
+            $this->createTestTool(),
+            ['deploymentIdentifier'],
+            $this->createTestKeyChain('platformKeyChain'),
+            $this->createTestKeyChain('toolKeyChain'),
+            $platformJwksUrl,
+            $toolJwksUrl
+        );
+    }
+
     private function createTestRegistrationRepository(array $registrations = []): RegistrationRepositoryInterface
     {
         $registrations = !empty($registrations)

--- a/tests/Unit/Service/Client/LtiServiceClientTest.php
+++ b/tests/Unit/Service/Client/LtiServiceClientTest.php
@@ -519,6 +519,26 @@ class LtiServiceClientTest extends TestCase
         $this->subject->request($this->registration, 'GET', 'http://example.com', [], $scopes);
     }
 
+    public function testItThrowsAnLtiExceptionOnNullPlatformAudience(): void
+    {
+        $this->expectException(LtiException::class);
+        $this->expectExceptionMessage('Cannot generate credentials: Platform audience cannot be null');
+
+        $this->registration = $this->createTestRegistrationWithoutPlatformAudience();
+
+        $this->subject->request($this->registration, 'GET', 'http://example.com');
+    }
+
+    public function testItThrowsAnLtiExceptionOnNullPlatformOAuth2AccessTokenUrl(): void
+    {
+        $this->expectException(LtiException::class);
+        $this->expectExceptionMessage('Cannot generate credentials: Platform OAuth2 access token url cannot be null');
+
+        $this->registration = $this->createTestRegistrationWithoutPlatformOAuth2AccessTokenUrl();
+
+        $this->subject->request($this->registration, 'GET', 'http://example.com');
+    }
+
     private function generateAccessTokenCacheKey(RegistrationInterface $registration, array $scopes = []): string
     {
         return sprintf(


### PR DESCRIPTION
Changes:
- Added validation for required AUD claim properties in `LtiServiceClient` as the JWT build could fail if the platform's OAuth2 Access Token URL is not defined