### PR TITLE
Support for version 4.2.0 of lcobucci/jwt

### DIFF
--- a/src/Security/Jwt/Configuration/ConfigurationFactory.php
+++ b/src/Security/Jwt/Configuration/ConfigurationFactory.php
@@ -85,7 +85,8 @@ class ConfigurationFactory
     private function convertKey(?KeyInterface $key = null): Key
     {
         if (null === $key) {
-            return InMemory::plainText('');
+            /** @psalm-suppress UndefinedMethod */
+            try { return InMemory::empty(); } catch (\Throwable $t) { return InMemory::plainText(''); }
         }
 
         return $this->converter->convert($key);


### PR DESCRIPTION
Hi there,

The [4.2.0 version](https://github.com/lcobucci/jwt/releases/tag/4.2.0) of `lcobucci/jwt` does not allow you to create an empty `InMemory`-key anymore using `InMemory::plainText('')`. Using this construct now results in an exception, breaking different flows through this library.

This PR solves this issue by using the dedicated method to create such an empty key. There is some more code needed to make sure the code also works with the PHP 7 branches (as they depend on an older version of the library). 

Please let me know if you need any additional information or tests.