### PR TITLE
[RELEASE] [SOLAR-68] tao 3 x sso

### DIFF
--- a/src/Message/Launch/Validator/AbstractLaunchValidator.php
+++ b/src/Message/Launch/Validator/AbstractLaunchValidator.php
@@ -51,6 +51,12 @@ abstract class AbstractLaunchValidator implements LaunchValidatorInterface
     /** @var string[] */
     protected $successes = [];
 
+    /** @var bool */
+    protected $isStateValidationRequired = true;
+
+    /** @var bool */
+    protected $isNonceValidationRequired = true;
+
     public function __construct(
         RegistrationRepositoryInterface $registrationRepository,
         NonceRepositoryInterface $nonceRepository,
@@ -77,5 +83,15 @@ abstract class AbstractLaunchValidator implements LaunchValidatorInterface
         $this->successes = [];
 
         return $this;
+    }
+
+    public function isStateValidationRequired(): bool
+    {
+        return $this->isStateValidationRequired;
+    }
+
+    public function isNonceValidationRequired(): bool
+    {
+        return $this->isNonceValidationRequired;
     }
 }

--- a/src/Message/Launch/Validator/Tool/ToolLaunchValidator.php
+++ b/src/Message/Launch/Validator/Tool/ToolLaunchValidator.php
@@ -88,11 +88,19 @@ class ToolLaunchValidator extends AbstractLaunchValidator implements ToolLaunchV
                 ->validatePayloadVersion($payload)
                 ->validatePayloadMessageType($payload)
                 ->validatePayloadRoles($payload)
-                ->validatePayloadUserIdentifier($payload)
-                ->validatePayloadNonce($payload)
+                ->validatePayloadUserIdentifier($payload);
+
+            if ($this->isNonceValidationRequired()) {
+                $this->validatePayloadNonce($payload);
+            }
+
+            $this
                 ->validatePayloadDeploymentId($registration, $payload)
-                ->validatePayloadLaunchMessageTypeSpecifics($payload)
-                ->validateStateToken($registration, $state);
+                ->validatePayloadLaunchMessageTypeSpecifics($payload);
+
+            if ($this->isStateValidationRequired()) {
+                $this->validateStateToken($registration, $state);
+            }
 
             return new LaunchValidationResult($registration, $payload, $state, $this->successes);
 


### PR DESCRIPTION
Ticket: https://oat-sa.atlassian.net/browse/SOLAR-68

## What's Changed

- introduced the ability to choose which validations to use for the nonce and state validations

## TODO 

- [x] Unit tests

## How to test
- Implement a Concrete Launch Validate which extends AbstractLaunchValidator
- Disable one of the validators `isStateValidationRequired` or `isNonceValidationRequired` by setting the attributes as false
- call validatePlatformOriginatingLaunch method