### PR TITLE
fix: bump phpseclib to 3.0.34

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "nesbot/carbon": "^2.43",
         "nyholm/psr7": "^1.3",
         "php-http/message-factory": "^1.1",
-        "phpseclib/phpseclib": "^2.0.31",
+        "phpseclib/phpseclib": "^3.0.34",
         "psr/cache": "^1.0 || ^2.0 || ^3.0",
         "psr/http-message": "^1.0",
         "psr/http-server-handler": "^1.0",


### PR DESCRIPTION
Update phpseclib to [3.0.34](https://github.com/phpseclib/phpseclib/releases/tag/3.0.34)

fixes https://github.com/oat-sa/lib-lti1p3-core/issues/168