### PR TITLE
Fix: pass the existing nonce back to the tool when performing OIDC authentication

### DIFF
--- a/src/Security/Oidc/OidcAuthenticator.php
+++ b/src/Security/Oidc/OidcAuthenticator.php
@@ -108,6 +108,12 @@ class OidcAuthenticator
                 ->withClaim(LtiMessagePayloadInterface::CLAIM_ISS, $registration->getPlatform()->getAudience())
                 ->withClaim(LtiMessagePayloadInterface::CLAIM_AUD, $registration->getClientId());
 
+            // If the original request contained a nonce, add it to the payload (fixes #154)
+            $nonce = $oidcRequest->getParameters()->get('nonce');
+            if ($nonce) {
+                $this->builder->withClaim(LtiMessagePayloadInterface::CLAIM_NONCE, $nonce);
+            }
+
             if (!$authenticationResult->isAnonymous()) {
                 foreach ($authenticationResult->getUserIdentity()->normalize() as $claimName => $claimValue) {
                     $this->builder->withClaim($claimName, $claimValue);
@@ -123,7 +129,6 @@ class OidcAuthenticator
                     'state' => $oidcRequest->getParameters()->getMandatory('state')
                 ]
             );
-
         } catch (LtiExceptionInterface $exception) {
             throw $exception;
         } catch (Throwable $exception) {

--- a/tests/Unit/Security/Oidc/OidcAuthenticatorTest.php
+++ b/tests/Unit/Security/Oidc/OidcAuthenticatorTest.php
@@ -57,7 +57,7 @@ class OidcAuthenticatorTest extends TestCase
         $this->repositoryMock = $this->createMock(RegistrationRepositoryInterface::class);
         $this->authenticatorMock = $this->createMock(UserAuthenticatorInterface::class);
 
-        $this->subject= new OidcAuthenticator($this->repositoryMock, $this->authenticatorMock);
+        $this->subject = new OidcAuthenticator($this->repositoryMock, $this->authenticatorMock);
     }
 
     public function testAuthenticationSuccess(): void
@@ -73,6 +73,7 @@ class OidcAuthenticatorTest extends TestCase
             [
                 LtiMessagePayloadInterface::CLAIM_LTI_TARGET_LINK_URI => 'target_link_uri',
                 LtiMessagePayloadInterface::CLAIM_REGISTRATION_ID => $registration->getIdentifier(),
+                LtiMessagePayloadInterface::CLAIM_NONCE => 'nonce',
 
             ],
             $registration->getToolKeyChain()->getPrivateKey()
@@ -105,6 +106,10 @@ class OidcAuthenticatorTest extends TestCase
         $this->assertEquals(
             $registration->getIdentifier(),
             $idToken->getClaims()->get(LtiMessagePayloadInterface::CLAIM_REGISTRATION_ID)
+        );
+        $this->assertEquals(
+            'nonce',
+            $idToken->getClaims()->get(LtiMessagePayloadInterface::CLAIM_NONCE)
         );
     }
 


### PR DESCRIPTION
Use the nonce from the original request when performing the OIDC authentication instead of generating a new one (which will cause validation to fail).

Fixes #154 