### PR TITLE
fix: the iat (issued at) value in the generated JWT by stripping off the microseconds

### DIFF
--- a/src/Security/Jwt/Builder/Builder.php
+++ b/src/Security/Jwt/Builder/Builder.php
@@ -61,7 +61,7 @@ class Builder implements BuilderInterface
     public function build(array $headers, array $claims, KeyInterface $key): TokenInterface
     {
         try {
-            $now = Carbon::now();
+            $now = Carbon::now()->setMicrosecond(0);
             $config = $this->factory->create($key);
             $builder = $config->builder();
 


### PR DESCRIPTION
Fix #153 

This PR aims to fix an issue with Blackboard instances not accepting microseconds for the iat, resulting in a `400 Bad Request` with the following error:

```json
{
    "error":"invalid_jwt_token",
    "error_description":"iat missing"
}
```