### PR TITLE
feat: throw separate exception type for invalid request

### DIFF
--- a/src/Exception/LtiBadRequestException.php
+++ b/src/Exception/LtiBadRequestException.php
@@ -22,8 +22,6 @@ declare(strict_types=1);
 
 namespace OAT\Library\Lti1p3Core\Exception;
 
-use Exception;
-
-class LtiBadRequestException extends Exception implements LtiExceptionInterface
+class LtiBadRequestException extends LtiException implements LtiExceptionInterface
 {
 }

--- a/src/Exception/LtiBadRequestException.php
+++ b/src/Exception/LtiBadRequestException.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2024 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace OAT\Library\Lti1p3Core\Exception;
+
+use Exception;
+
+class LtiBadRequestException extends Exception implements LtiExceptionInterface
+{
+}

--- a/src/Security/Oidc/OidcAuthenticator.php
+++ b/src/Security/Oidc/OidcAuthenticator.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 namespace OAT\Library\Lti1p3Core\Security\Oidc;
 
 use OAT\Library\Lti1p3Core\Exception\LtiException;
+use OAT\Library\Lti1p3Core\Exception\LtiBadRequestException;
 use OAT\Library\Lti1p3Core\Exception\LtiExceptionInterface;
 use OAT\Library\Lti1p3Core\Message\LtiMessage;
 use OAT\Library\Lti1p3Core\Message\LtiMessageInterface;
@@ -80,6 +81,10 @@ class OidcAuthenticator
         try {
             $oidcRequest = LtiMessage::fromServerRequest($request);
 
+            if (!$oidcRequest->getParameters()->has('lti_message_hint')) {
+                throw new LtiBadRequestException('Missing LTI message hint in request');
+            }
+
             $originalToken = $this->parser->parse($oidcRequest->getParameters()->get('lti_message_hint'));
 
             $registration = $this->repository->find(
@@ -87,11 +92,11 @@ class OidcAuthenticator
             );
 
             if (null === $registration) {
-                throw new LtiException('Invalid message hint registration id claim');
+                throw new LtiBadRequestException('Invalid message hint registration id claim');
             }
 
             if (!$this->validator->validate($originalToken, $registration->getPlatformKeyChain()->getPublicKey())) {
-                throw new LtiException('Invalid message hint');
+                throw new LtiBadRequestException('Invalid message hint');
             }
 
             $authenticationResult = $this->authenticator->authenticate(

--- a/src/Security/Oidc/OidcAuthenticator.php
+++ b/src/Security/Oidc/OidcAuthenticator.php
@@ -85,7 +85,7 @@ class OidcAuthenticator
                 throw new LtiBadRequestException('Missing LTI message hint in request');
             }
 
-            $originalToken = $this->parser->parse($oidcRequest->getParameters()->get('lti_message_hint'));
+            $originalToken = $this->parser->parse($oidcRequest->getParameters()->getMandatory('lti_message_hint'));
 
             $registration = $this->repository->find(
                 $originalToken->getClaims()->getMandatory(LtiMessagePayloadInterface::CLAIM_REGISTRATION_ID)

--- a/src/Security/Oidc/OidcInitiator.php
+++ b/src/Security/Oidc/OidcInitiator.php
@@ -22,6 +22,8 @@ declare(strict_types=1);
 
 namespace OAT\Library\Lti1p3Core\Security\Oidc;
 
+use InvalidArgumentException;
+use OAT\Library\Lti1p3Core\Exception\LtiBadRequestException;
 use OAT\Library\Lti1p3Core\Exception\LtiException;
 use OAT\Library\Lti1p3Core\Exception\LtiExceptionInterface;
 use OAT\Library\Lti1p3Core\Message\LtiMessage;
@@ -121,6 +123,12 @@ class OidcInitiator
 
         } catch (LtiExceptionInterface $exception) {
             throw $exception;
+        } catch (InvalidArgumentException $exception) {
+            throw new LtiBadRequestException(
+                sprintf('OIDC initiation request failed: %s', $exception->getMessage()),
+                $exception->getCode(),
+                $exception
+            );
         } catch (Throwable $exception) {
             throw new LtiException(
                 sprintf('OIDC initiation failed: %s', $exception->getMessage()),

--- a/tests/Unit/Security/Oidc/OidcAuthenticatorTest.php
+++ b/tests/Unit/Security/Oidc/OidcAuthenticatorTest.php
@@ -24,6 +24,7 @@ namespace OAT\Library\Lti1p3Core\Tests\Unit\Security\Oidc;
 
 use Carbon\Carbon;
 use Exception;
+use OAT\Library\Lti1p3Core\Exception\LtiBadRequestException;
 use OAT\Library\Lti1p3Core\Exception\LtiException;
 use OAT\Library\Lti1p3Core\Message\LtiMessageInterface;
 use OAT\Library\Lti1p3Core\Message\Payload\LtiMessagePayloadInterface;
@@ -165,7 +166,7 @@ class OidcAuthenticatorTest extends TestCase
 
     public function testAuthenticationFailureOnExpiredMessageHint(): void
     {
-        $this->expectException(LtiException::class);
+        $this->expectException(LtiBadRequestException::class);
         $this->expectExceptionMessage('Invalid message hint');
 
         $registration = $this->createTestRegistration();
@@ -198,9 +199,19 @@ class OidcAuthenticatorTest extends TestCase
         $this->subject->authenticate($request);
     }
 
+    public function testAuthenticationFailureOnMissingMessageHint(): void
+    {
+        $this->expectException(LtiBadRequestException::class);
+        $this->expectExceptionMessage('Missing LTI message hint in request');
+
+        $request = $this->createServerRequest('GET','http://platform.com/init');
+
+        $this->subject->authenticate($request);
+    }
+
     public function testAuthenticationFailureOnRegistrationNotFound(): void
     {
-        $this->expectException(LtiException::class);
+        $this->expectException(LtiBadRequestException::class);
         $this->expectExceptionMessage('Invalid message hint registration id claim');
 
         $registration = $this->createTestRegistration();

--- a/tests/Unit/Security/Oidc/OidcInitiatorTest.php
+++ b/tests/Unit/Security/Oidc/OidcInitiatorTest.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 namespace OAT\Library\Lti1p3Core\Tests\Unit\Security\Oidc;
 
 use Exception;
+use OAT\Library\Lti1p3Core\Exception\LtiBadRequestException;
 use OAT\Library\Lti1p3Core\Exception\LtiException;
 use OAT\Library\Lti1p3Core\Registration\RegistrationInterface;
 use OAT\Library\Lti1p3Core\Registration\RegistrationRepositoryInterface;
@@ -147,6 +148,16 @@ class OidcInitiatorTest extends TestCase
                 'client_id' => 'client_id'
             ]))
         );
+
+        $this->subject->initiate($request);
+    }
+
+    public function testInitiationFailureOnMissingMandatoryRequestParams(): void
+    {
+        $this->expectException(LtiBadRequestException::class);
+        $this->expectExceptionMessage('OIDC initiation request failed: Missing mandatory iss');
+
+        $request = $this->createServerRequest('GET','http://tool.com/init');
 
         $this->subject->initiate($request);
     }


### PR DESCRIPTION
Cause the lib takes care of a request validation it makes sense to split internal logic errors (aka 500) from input validation errors in order to allow an application to properly show/hide error messages / provide statuses for user