### PR TITLE
Support custom role claims

### DIFF
--- a/src/Role/Factory/RoleFactory.php
+++ b/src/Role/Factory/RoleFactory.php
@@ -28,6 +28,7 @@ use OAT\Library\Lti1p3Core\Role\Type\ContextRole;
 use OAT\Library\Lti1p3Core\Role\Type\InstitutionRole;
 use OAT\Library\Lti1p3Core\Role\Type\LtiSystemRole;
 use OAT\Library\Lti1p3Core\Role\Type\SystemRole;
+use OAT\Library\Lti1p3Core\Role\Type\TaoRole;
 
 class RoleFactory
 {
@@ -36,16 +37,20 @@ class RoleFactory
      */
     public static function create(string $name): RoleInterface
     {
-        if (strpos($name, SystemRole::getNameSpace()) === 0) {
+        if (str_starts_with($name, SystemRole::getNameSpace())) {
             return new SystemRole($name);
         }
 
-        if (strpos($name, InstitutionRole::getNameSpace()) === 0) {
+        if (str_starts_with($name, InstitutionRole::getNameSpace())) {
             return new InstitutionRole($name);
         }
 
-        if (strpos($name, LtiSystemRole::getNameSpace()) === 0) {
+        if (str_starts_with($name, LtiSystemRole::getNameSpace())) {
             return new LtiSystemRole($name);
+        }
+
+        if (str_starts_with($name, TaoRole::getNameSpace())) {
+            return new TaoRole($name);
         }
 
         return new ContextRole($name);

--- a/src/Role/Factory/RoleFactory.php
+++ b/src/Role/Factory/RoleFactory.php
@@ -28,7 +28,7 @@ use OAT\Library\Lti1p3Core\Role\Type\ContextRole;
 use OAT\Library\Lti1p3Core\Role\Type\InstitutionRole;
 use OAT\Library\Lti1p3Core\Role\Type\LtiSystemRole;
 use OAT\Library\Lti1p3Core\Role\Type\SystemRole;
-use OAT\Library\Lti1p3Core\Role\Type\TaoRole;
+use OAT\Library\Lti1p3Core\Role\Type\CustomRole;
 
 class RoleFactory
 {
@@ -49,8 +49,12 @@ class RoleFactory
             return new LtiSystemRole($name);
         }
 
-        if (str_starts_with($name, TaoRole::getNameSpace())) {
-            return new TaoRole($name);
+        if (str_starts_with($name, ContextRole::getNameSpace())) {
+            return new ContextRole($name);
+        }
+
+        if (filter_var($name, FILTER_VALIDATE_URL)) {
+            return new CustomRole($name);
         }
 
         return new ContextRole($name);

--- a/src/Role/RoleInterface.php
+++ b/src/Role/RoleInterface.php
@@ -31,11 +31,13 @@ interface RoleInterface
     public const TYPE_INSTITUTION = 'institution';
     public const TYPE_CONTEXT = 'context';
     public const TYPE_LTI_SYSTEM = 'lti-system';
+    public const TYPE_CUSTOM_TAO = 'non-lti-tao';
 
     public const NAMESPACE_SYSTEM = 'http://purl.imsglobal.org/vocab/lis/v2/system/person';
     public const NAMESPACE_INSTITUTION = 'http://purl.imsglobal.org/vocab/lis/v2/institution/person';
     public const NAMESPACE_CONTEXT = 'http://purl.imsglobal.org/vocab/lis/v2/membership';
     public const NAMESPACE_LTI_SYSTEM = 'http://purl.imsglobal.org/vocab/lti/system/person';
+    public const NAMESPACE_CUSTOM_TAO = 'http://www.tao.lu/Ontologies/TAOLTI.rdf';
 
     public static function getType(): string;
 

--- a/src/Role/RoleInterface.php
+++ b/src/Role/RoleInterface.php
@@ -31,13 +31,12 @@ interface RoleInterface
     public const TYPE_INSTITUTION = 'institution';
     public const TYPE_CONTEXT = 'context';
     public const TYPE_LTI_SYSTEM = 'lti-system';
-    public const TYPE_CUSTOM_TAO = 'non-lti-tao';
+    public const TYPE_CUSTOM_TAO = 'non-lti-custom';
 
     public const NAMESPACE_SYSTEM = 'http://purl.imsglobal.org/vocab/lis/v2/system/person';
     public const NAMESPACE_INSTITUTION = 'http://purl.imsglobal.org/vocab/lis/v2/institution/person';
     public const NAMESPACE_CONTEXT = 'http://purl.imsglobal.org/vocab/lis/v2/membership';
     public const NAMESPACE_LTI_SYSTEM = 'http://purl.imsglobal.org/vocab/lti/system/person';
-    public const NAMESPACE_CUSTOM_TAO = 'http://www.tao.lu/Ontologies/TAOLTI.rdf';
 
     public static function getType(): string;
 

--- a/src/Role/Type/CustomRole.php
+++ b/src/Role/Type/CustomRole.php
@@ -15,7 +15,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2021 (original work) Open Assessment Technologies SA;
+ * Copyright (c) 2025 (original work) Open Assessment Technologies SA;
  */
 
 declare(strict_types=1);

--- a/src/Role/Type/CustomRole.php
+++ b/src/Role/Type/CustomRole.php
@@ -27,7 +27,7 @@ use OAT\Library\Lti1p3Core\Role\AbstractRole;
 /**
  * @see https://www.imsglobal.org/node/162741#roles-claim
  */
-class TaoRole extends AbstractRole
+class CustomRole extends AbstractRole
 {
     public static function getType(): string
     {
@@ -36,7 +36,7 @@ class TaoRole extends AbstractRole
 
     public static function getNameSpace(): string
     {
-        return static::NAMESPACE_CUSTOM_TAO;
+        return '';
     }
 
     public function getSubName(): ?string

--- a/src/Role/Type/TaoRole.php
+++ b/src/Role/Type/TaoRole.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace OAT\Library\Lti1p3Core\Role\Type;
+
+use OAT\Library\Lti1p3Core\Role\AbstractRole;
+
+/**
+ * @see https://www.imsglobal.org/node/162741#roles-claim
+ */
+class TaoRole extends AbstractRole
+{
+    public static function getType(): string
+    {
+        return static::TYPE_CUSTOM_TAO;
+    }
+
+    public static function getNameSpace(): string
+    {
+        return static::NAMESPACE_CUSTOM_TAO;
+    }
+
+    public function getSubName(): ?string
+    {
+        $exp = explode('#', $this->name);
+        return end($exp);
+    }
+
+    public function isCore(): bool
+    {
+        return false;
+    }
+
+    protected function isValid(): bool
+    {
+        return count(explode('#', $this->name)) === 2;
+    }
+
+    protected function getMap(): array
+    {
+        return [];
+    }
+}

--- a/tests/Unit/Role/Factory/RoleFactoryTest.php
+++ b/tests/Unit/Role/Factory/RoleFactoryTest.php
@@ -28,7 +28,7 @@ use OAT\Library\Lti1p3Core\Role\Type\ContextRole;
 use OAT\Library\Lti1p3Core\Role\Type\InstitutionRole;
 use OAT\Library\Lti1p3Core\Role\Type\LtiSystemRole;
 use OAT\Library\Lti1p3Core\Role\Type\SystemRole;
-use OAT\Library\Lti1p3Core\Role\Type\TaoRole;
+use OAT\Library\Lti1p3Core\Role\Type\CustomRole;
 use PHPUnit\Framework\TestCase;
 
 class RoleFactoryTest extends TestCase
@@ -97,7 +97,7 @@ class RoleFactoryTest extends TestCase
     {
         $result = RoleFactory::create('http://www.tao.lu/Ontologies/TAOLTI.rdf#ContentTranslator');
 
-        $this->assertInstanceOf(TaoRole::class, $result);
+        $this->assertInstanceOf(CustomRole::class, $result);
         $this->assertEquals('http://www.tao.lu/Ontologies/TAOLTI.rdf#ContentTranslator', $result->getName());
         $this->assertEquals('ContentTranslator', $result->getSubName());
         $this->assertFalse($result->isCore());

--- a/tests/Unit/Role/Factory/RoleFactoryTest.php
+++ b/tests/Unit/Role/Factory/RoleFactoryTest.php
@@ -28,6 +28,7 @@ use OAT\Library\Lti1p3Core\Role\Type\ContextRole;
 use OAT\Library\Lti1p3Core\Role\Type\InstitutionRole;
 use OAT\Library\Lti1p3Core\Role\Type\LtiSystemRole;
 use OAT\Library\Lti1p3Core\Role\Type\SystemRole;
+use OAT\Library\Lti1p3Core\Role\Type\TaoRole;
 use PHPUnit\Framework\TestCase;
 
 class RoleFactoryTest extends TestCase
@@ -90,6 +91,16 @@ class RoleFactoryTest extends TestCase
         $this->assertEquals('http://purl.imsglobal.org/vocab/lti/system/person#TestUser', $result->getName());
         $this->assertNull($result->getSubName());
         $this->assertTrue($result->isCore());
+    }
+
+    public function testCreateTaoRole(): void
+    {
+        $result = RoleFactory::create('http://www.tao.lu/Ontologies/TAOLTI.rdf#ContentTranslator');
+
+        $this->assertInstanceOf(TaoRole::class, $result);
+        $this->assertEquals('http://www.tao.lu/Ontologies/TAOLTI.rdf#ContentTranslator', $result->getName());
+        $this->assertEquals('ContentTranslator', $result->getSubName());
+        $this->assertFalse($result->isCore());
     }
 
     public function testCreateFailure(): void


### PR DESCRIPTION
[From specification](https://www.imsglobal.org/node/162741#roles-claim):

> ...If the sender of the message wants to include **a role from another vocabulary namespace**, by best practice **it should
> use a fully-qualified URI** to identify the role......
> ....it MUST contain at least one role from the role vocabularies described in [role vocabularies]

So this PR aims to allow non-vocabulary role claims in a form of URI