### PR TITLE
fix aud claim validation in tool launch validator

### DIFF
--- a/src/Message/Launch/Validator/Tool/ToolLaunchValidator.php
+++ b/src/Message/Launch/Validator/Tool/ToolLaunchValidator.php
@@ -76,6 +76,9 @@ class ToolLaunchValidator extends AbstractLaunchValidator implements ToolLaunchV
                     $payload->getMandatoryClaim(MessagePayloadInterface::CLAIM_ISS),
                     $audience
                 );
+                if ($registration !== null) {
+                  break;
+                }
             }
 
             if (null === $registration) {


### PR DESCRIPTION
The validation for the `aud` claim is faulty when multiple audiences are defined.

It should match ANY not just the last entry.