### PR TITLE
Add lcobucci/jwt: ^5.0 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "ext-openssl": "*",
         "codercat/jwk-to-pem": "^1.1",
         "guzzlehttp/guzzle": "^7.8",
-        "lcobucci/jwt": "^4.3",
+        "lcobucci/jwt": "^4.3 || ^5.0",
         "league/oauth2-server": "^8.5 || ^9.2",
         "nesbot/carbon": "^2.72 || ^3.0",
         "nyholm/psr7": "^1.8",

--- a/src/Security/Jwt/Builder/Builder.php
+++ b/src/Security/Jwt/Builder/Builder.php
@@ -66,7 +66,7 @@ class Builder implements BuilderInterface
             $builder = $config->builder();
 
             foreach ($headers as $headerName => $headerValue) {
-                $builder->withHeader($headerName, $headerValue);
+                $builder = $builder->withHeader($headerName, $headerValue);
             }
 
             $claims = array_merge(
@@ -81,34 +81,34 @@ class Builder implements BuilderInterface
             foreach ($claims as $claimName => $claimValue) {
                 switch ($claimName) {
                     case MessagePayloadInterface::CLAIM_JTI:
-                        $builder->identifiedBy($claimValue);
+                        $builder = $builder->identifiedBy($claimValue);
                         break;
                     case MessagePayloadInterface::CLAIM_EXP:
-                        $builder->expiresAt($claimValue);
+                        $builder = $builder->expiresAt($claimValue);
                         break;
                     case MessagePayloadInterface::CLAIM_NBF:
-                        $builder->canOnlyBeUsedAfter($claimValue);
+                        $builder = $builder->canOnlyBeUsedAfter($claimValue);
                         break;
                     case MessagePayloadInterface::CLAIM_IAT:
-                        $builder->issuedAt($claimValue);
+                        $builder = $builder->issuedAt($claimValue);
                         break;
                     case MessagePayloadInterface::CLAIM_SUB:
-                        $builder->relatedTo($claimValue);
+                        $builder = $builder->relatedTo($claimValue);
                         break;
                     case MessagePayloadInterface::CLAIM_ISS:
-                        $builder->issuedBy($claimValue);
+                        $builder = $builder->issuedBy($claimValue);
                         break;
                     case MessagePayloadInterface::CLAIM_AUD:
                         if (is_array($claimValue)) {
                             foreach ($claimValue as $audience) {
-                                $builder->permittedFor($audience);
+                                $builder = $builder->permittedFor($audience);
                             }
                         } else {
-                            $builder->permittedFor($claimValue);
+                            $builder = $builder->permittedFor($claimValue);
                         }
                         break;
                     default:
-                        $builder->withClaim($claimName, $claimValue);
+                        $builder = $builder->withClaim($claimName, $claimValue);
                 }
             }
 


### PR DESCRIPTION
So far the only code change I've seen that is required is to the JWT builder: `lcobucci/jwt:5.0` makes the builder API immutable, see https://lcobucci-jwt.readthedocs.io/en/latest/upgrading/#builder-api-is-now-immutable.

This passes PHPUnit tests with both `lcobucci/jwt` versions `4.3` and `5.5`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded support for a broader range of versions of the "lcobucci/jwt" library to improve compatibility.
* **Refactor**
  * Improved internal handling of token building to ensure correct processing and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->