### PR TITLE
Prioritize JWKS URL over static key chain in validatePayload

### DIFF
--- a/src/Message/Launch/Validator/Platform/PlatformLaunchValidator.php
+++ b/src/Message/Launch/Validator/Platform/PlatformLaunchValidator.php
@@ -152,12 +152,10 @@ class PlatformLaunchValidator extends AbstractLaunchValidator implements Platfor
     {
         $toolKeyChain = $registration->getToolKeyChain();
 
-        $key = $toolKeyChain
-            ? $toolKeyChain->getPublicKey()
-            : $this->fetcher->fetchKey(
-                $registration->getToolJwksUrl(),
-                $payload->getToken()->getHeaders()->getMandatory(LtiMessagePayloadInterface::HEADER_KID)
-            );
+        $key = $registration->getToolJwksUrl() ? $this->fetcher->fetchKey(
+            $registration->getToolJwksUrl(),
+            $payload->getToken()->getHeaders()->getMandatory(LtiMessagePayloadInterface::HEADER_KID)
+        ) : $registration->getToolKeyChain()->getPublicKey();
 
         if (!$this->validator->validate($payload->getToken(), $key)) {
             throw new LtiException('JWT validation failure');


### PR DESCRIPTION
Currently, validatePayload() checks the tool key chain before attempting to fetch the key from the tool's JWKS URL. This commit reverses the precedence, ensuring that if a JWKS URL is provided by the registration, it is used to fetch the public key for JWT validation.

Fallback to the static key chain is preserved if no JWKS URL is available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the method for selecting the key used to validate JWT payloads, ensuring more reliable key retrieval and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->