### PR TITLE
Fix(OidcInitiator): prevent `lti_message_hint`, `login_hint`, and `target_link_uri` from being duplicated in the `state` JWT

### DIFF
--- a/src/Security/Oidc/OidcInitiator.php
+++ b/src/Security/Oidc/OidcInitiator.php
@@ -120,7 +120,7 @@ class OidcInitiator
                 [
                     'redirect_uri' => $oidcRequest->getParameters()->getMandatory('target_link_uri'),
                     'client_id' => $registration->getClientId(),
-                    'login_hint' => $oidcRequest->getParameters()->getMandatory('login_hint'),
+                    'login_hint' => $loginHint,
                     'nonce' => $nonce->getValue(),
                     'state' => $statePayload->getToken()->toString(),
                     'lti_message_hint' => $ltiMessageHint,

--- a/src/Security/Oidc/OidcInitiator.php
+++ b/src/Security/Oidc/OidcInitiator.php
@@ -96,6 +96,8 @@ class OidcInitiator
 
             $nonce = $this->generator->generate();
 
+            $redirectUri = $oidcRequest->getParameters()->getMandatory('target_link_uri');
+            $loginHint = $oidcRequest->getParameters()->getMandatory('login_hint');
             $ltiMessageHint = $oidcRequest->getParameters()->get('lti_message_hint');
 
             $this->builder

--- a/src/Security/Oidc/OidcInitiator.php
+++ b/src/Security/Oidc/OidcInitiator.php
@@ -96,11 +96,14 @@ class OidcInitiator
 
             $nonce = $this->generator->generate();
 
+            $ltiMessageHint = $oidcRequest->getParameters()->get('lti_message_hint');
+
             $this->builder
                 ->withClaim(LtiMessagePayloadInterface::CLAIM_SUB, $registration->getIdentifier())
                 ->withClaim(LtiMessagePayloadInterface::CLAIM_ISS, $registration->getTool()->getAudience())
                 ->withClaim(LtiMessagePayloadInterface::CLAIM_AUD, $registration->getPlatform()->getAudience())
-                ->withClaim(LtiMessagePayloadInterface::CLAIM_NONCE, $nonce->getValue());
+                ->withClaim(LtiMessagePayloadInterface::CLAIM_NONCE, $nonce->getValue())
+                ->withClaim(LtiMessagePayloadInterface::CLAIM_PARAMETERS, $oidcRequest->getParameters()->remove('lti_message_hint'));
 
             $statePayload = $this->builder->buildMessagePayload($toolKeyChain);
 
@@ -112,7 +115,7 @@ class OidcInitiator
                     'login_hint' => $oidcRequest->getParameters()->getMandatory('login_hint'),
                     'nonce' => $nonce->getValue(),
                     'state' => $statePayload->getToken()->toString(),
-                    'lti_message_hint' => $oidcRequest->getParameters()->get('lti_message_hint'),
+                    'lti_message_hint' => $ltiMessageHint,
                     'scope' => 'openid',
                     'response_type' => 'id_token',
                     'response_mode' => 'form_post',

--- a/src/Security/Oidc/OidcInitiator.php
+++ b/src/Security/Oidc/OidcInitiator.php
@@ -100,8 +100,7 @@ class OidcInitiator
                 ->withClaim(LtiMessagePayloadInterface::CLAIM_SUB, $registration->getIdentifier())
                 ->withClaim(LtiMessagePayloadInterface::CLAIM_ISS, $registration->getTool()->getAudience())
                 ->withClaim(LtiMessagePayloadInterface::CLAIM_AUD, $registration->getPlatform()->getAudience())
-                ->withClaim(LtiMessagePayloadInterface::CLAIM_NONCE, $nonce->getValue())
-                ->withClaim(LtiMessagePayloadInterface::CLAIM_PARAMETERS, $oidcRequest->getParameters());
+                ->withClaim(LtiMessagePayloadInterface::CLAIM_NONCE, $nonce->getValue());
 
             $statePayload = $this->builder->buildMessagePayload($toolKeyChain);
 

--- a/src/Security/Oidc/OidcInitiator.php
+++ b/src/Security/Oidc/OidcInitiator.php
@@ -118,7 +118,7 @@ class OidcInitiator
             return new LtiMessage(
                 $registration->getPlatform()->getOidcAuthenticationUrl(),
                 [
-                    'redirect_uri' => $oidcRequest->getParameters()->getMandatory('target_link_uri'),
+                    'redirect_uri' => $redirectUri,
                     'client_id' => $registration->getClientId(),
                     'login_hint' => $loginHint,
                     'nonce' => $nonce->getValue(),

--- a/src/Security/Oidc/OidcInitiator.php
+++ b/src/Security/Oidc/OidcInitiator.php
@@ -105,7 +105,13 @@ class OidcInitiator
                 ->withClaim(LtiMessagePayloadInterface::CLAIM_ISS, $registration->getTool()->getAudience())
                 ->withClaim(LtiMessagePayloadInterface::CLAIM_AUD, $registration->getPlatform()->getAudience())
                 ->withClaim(LtiMessagePayloadInterface::CLAIM_NONCE, $nonce->getValue())
-                ->withClaim(LtiMessagePayloadInterface::CLAIM_PARAMETERS, $oidcRequest->getParameters()->remove('lti_message_hint'));
+                ->withClaim(
+                    LtiMessagePayloadInterface::CLAIM_PARAMETERS,
+                    $oidcRequest->getParameters()
+                        ->remove('target_link_uri')
+                        ->remove('login_hint')
+                        ->remove('lti_message_hint')
+                );
 
             $statePayload = $this->builder->buildMessagePayload($toolKeyChain);
 


### PR DESCRIPTION
See issue details here: https://github.com/oat-sa/lib-lti1p3-core/issues/214

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OIDC sign-in initialization by correcting how sign-in message fields are handled, ensuring message hints are preserved and included in the returned payload.
  * This change increases compatibility and reliability during external authentication handshakes, reducing failed or misrouted sign-in attempts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->